### PR TITLE
Few tweaks and tricks to reduce gzipped size while supporting IE8

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -46,19 +46,8 @@
 		return value;
 	}
 
-	function processWrite (value) {
-		var stringified;
-		try {
-			stringified = JSON.stringify(value);
-			if (/^(?:\{[\w\W]*\}|\[[\w\W]*\])$/.test(stringified)) {
-				value = stringified;
-			}
-		} catch(e) {}
-		return encode(String(value), unallowedCharsInValue);
-	}
-
 	function processRead (value, converter, json) {
-		if (value.indexOf('"') === 0) {
+		if (value.charAt(0) === '"') {
 			// This is a quoted cookie as according to RFC2068, unescape...
 			value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
 		}
@@ -71,64 +60,72 @@
 			} catch(e) {}
 		}
 
-		return isFunction(converter) ? converter(value) : value;
+		return converter ? converter(value) : value;
 	}
 
 	function extend () {
-		var key, options;
 		var i = 0;
 		var result = {};
 		for (; i < arguments.length; i++) {
-			options = arguments[ i ];
-			for (key in options) {
+			var options = arguments[ i ];
+			for (var key in options) {
 				result[key] = options[key];
 			}
 		}
 		return result;
 	}
 
-	function isFunction (obj) {
-		return Object.prototype.toString.call(obj) === '[object Function]';
-	}
-
 	var api = function (key, value, options) {
-		var converter;
+		var converter, result;
+		var args = [].slice.call(arguments);
 
-		if (isFunction(value)) {
+		if (typeof value === 'function') {
 			converter = value;
-			value = undefined;
+			args.length = 1;
 		}
 
 		// Write
 
-		if (arguments.length > 1 && !converter) {
+		if (args.length > 1) {
 			options = extend(api.defaults, options);
 
 			if (typeof options.expires === 'number') {
-				var days = options.expires, t = options.expires = new Date();
-				t.setMilliseconds(t.getMilliseconds() + days * 864e+5);
+				var expires = new Date();
+				expires.setMilliseconds(expires.getMilliseconds() + options.expires * 864e+5);
+				options.expires = expires;
 			}
 
+			try {
+				result = JSON.stringify(value);
+				if (/^(?:\{[\w\W]*\}|\[[\w\W]*\])$/.test(result)) {
+					value = result;
+				}
+			} catch(e) {}
+
+			value = encode(String(value), unallowedCharsInValue);
+
 			return (document.cookie = [
-				encode(key, unallowedCharsInName), '=', processWrite(value),
-				options.expires ? '; expires=' + options.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
-				options.path    ? '; path=' + options.path : '',
-				options.domain  ? '; domain=' + options.domain : '',
-				options.secure  ? '; secure' : ''
+				encode(key, unallowedCharsInName), '=', value,
+				options.expires && '; expires=' + options.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
+				options.path    && '; path=' + options.path,
+				options.domain  && '; domain=' + options.domain,
+				options.secure  && '; secure'
 			].join(''));
 		}
 
 		// Read
 
-		var result = key ? undefined : {},
-			// To prevent the for loop in the first place assign an empty array
-			// in case there are no cookies at all. Also prevents odd result when
-			// calling "get()".
-			cookies = document.cookie ? document.cookie.split('; ') : [],
-			i = 0,
-			l = cookies.length;
+		if (!key) {
+			result = {};
+		}
 
-		for (; i < l; i++) {
+		// To prevent the for loop in the first place assign an empty array
+		// in case there are no cookies at all. Also prevents odd result when
+		// calling "get()"
+		var cookies = document.cookie ? document.cookie.split('; ') : [];
+		var i = 0;
+
+		for (; i < cookies.length; i++) {
 			var parts = cookies[i].split('='),
 				name = decode(parts.shift(), unallowedCharsInName),
 				cookie = parts.join('=');
@@ -148,7 +145,7 @@
 
 	api.get = api.set = api;
 	api.getJSON = function() {
-		return api.get.apply({
+		return api.apply({
 			json: true
 		}, [].slice.call(arguments));
 	};

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -48,8 +48,7 @@
 
 	function processRead (value, converter, json) {
 		if (value.charAt(0) === '"') {
-			// This is a quoted cookie as according to RFC2068, unescape...
-			value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+			value = value.slice(1, -1);
 		}
 
 		value = decode(value, unallowedCharsInValue);

--- a/test/tests.js
+++ b/test/tests.js
@@ -62,12 +62,6 @@ test('not existing', function () {
 	strictEqual(Cookies.get('whatever'), undefined, 'return undefined');
 });
 
-test('RFC 2068 quoted string', function () {
-	expect(1);
-	document.cookie = 'c="v@address.com\\"\\\\\\""';
-	strictEqual(Cookies.get('c'), 'v@address.com"\\"', 'should decode RFC 2068 quoted string');
-});
-
 // github.com/carhartl/jquery-cookie/issues/50
 test('equality sign in cookie value', function () {
 	expect(1);
@@ -216,7 +210,7 @@ test('defaults', function () {
 	ok(Cookies.set('c', 'v', { path: '/bar' }).match(/path=\/bar/), 'options argument has precedence');
 });
 
-test('Quote in the cookie value', function () {
+test('Handling quotes in the cookie value for read and write', function () {
 	expect(3);
 
 	Cookies.set('quote', '"');
@@ -229,7 +223,13 @@ test('Quote in the cookie value', function () {
 	strictEqual(Cookies.get('without-first'), 'content"', 'should print the quote character');
 });
 
-test('RFC 6265 disallowed characters in cookie-octet', function () {
+test('RFC 6265 - cookie-octet enclosed in DQUOTE', function () {
+	expect(1);
+	document.cookie = 'c="v"';
+	strictEqual(Cookies.get('c'), 'v', 'should decode the quotes');
+});
+
+test('RFC 6265 - disallowed characters in cookie-octet', function () {
 	expect(5);
 
 	Cookies.set('whitespace', ' ');
@@ -248,7 +248,7 @@ test('RFC 6265 disallowed characters in cookie-octet', function () {
 	strictEqual(Cookies.get('multiple'), '" ,;\\" ,;\\', 'should handle multiple special characters');
 });
 
-test('RFC 6265 disallowed characters in cookie-name', function () {
+test('RFC 6265 - disallowed characters in cookie-name', function () {
 	expect(18);
 
 	Cookies.set('(', 'v');


### PR DESCRIPTION
https://github.com/js-cookie/js-cookie/commit/78a3b44b82c997b9b682af1b34b72a664f8cc563:
```shell
raw     gz Sizes
1567    838 build/js.cookie-2.0.0-pre.min.js
3859   1494 src/js.cookie.js

raw     gz Compared to 2.0 @ 2847ee7906960acfe25821284b24ead5d697c4c3
-91    -54 build/js.cookie-2.0.0-pre.min.js
-182   -89 src/js.cookie.js

raw     gz Compared to master
+14    +13 build/js.cookie-2.0.0-pre.min.js
+132   -57 src/js.cookie.js
```

https://github.com/js-cookie/js-cookie/commit/d02fac4fb932eb538860bfad2997199ec16c212d (after the merge of `quoted-string` branch):

```shell
raw     gz Sizes
1525    820 build/js.cookie-2.0.0-pre.min.js
3747   1432 src/js.cookie.js

raw     gz Compared to 2.0 @ 2847ee7906960acfe25821284b24ead5d697c4c3
-133    -72 build/js.cookie-2.0.0-pre.min.js
-294    -151 src/js.cookie.js

raw     gz Compared to master
-28    -5 build/js.cookie-2.0.0-pre.min.js
+20    -119 src/js.cookie.js
```