### PR TITLE
Enclosed quotes

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -48,8 +48,7 @@
 
 	function processRead (value, converter, json) {
 		if (value.charAt(0) === '"') {
-			// This is a quoted cookie as according to RFC2068, unescape...
-			value = value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+			value = value.slice(1, -1);
 		}
 
 		value = decode(value, unallowedCharsInValue);

--- a/test/tests.js
+++ b/test/tests.js
@@ -229,12 +229,6 @@ test('RFC 6265 - cookie-octet enclosed in DQUOTE', function () {
 	strictEqual(Cookies.get('c'), 'v', 'should decode the quotes');
 });
 
-test('RFC 6265 - cookie-octet with quotes enclosed in DQUOTE', function() {
-	expect(1);
-	document.cookie = 'c="with"quotes"';
-	strictEqual(Cookies.get('c'), 'with"quotes', 'should decode the quotes');
-});
-
 test('RFC 6265 - disallowed characters in cookie-octet', function () {
 	expect(5);
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -62,12 +62,6 @@ test('not existing', function () {
 	strictEqual(Cookies.get('whatever'), undefined, 'return undefined');
 });
 
-test('RFC 2068 quoted string', function () {
-	expect(1);
-	document.cookie = 'c="v@address.com\\"\\\\\\""';
-	strictEqual(Cookies.get('c'), 'v@address.com"\\"', 'should decode RFC 2068 quoted string');
-});
-
 // github.com/carhartl/jquery-cookie/issues/50
 test('equality sign in cookie value', function () {
 	expect(1);
@@ -216,7 +210,7 @@ test('defaults', function () {
 	ok(Cookies.set('c', 'v', { path: '/bar' }).match(/path=\/bar/), 'options argument has precedence');
 });
 
-test('Quote in the cookie value', function () {
+test('Handling quotes in the cookie value for read and write', function () {
 	expect(3);
 
 	Cookies.set('quote', '"');
@@ -229,7 +223,19 @@ test('Quote in the cookie value', function () {
 	strictEqual(Cookies.get('without-first'), 'content"', 'should print the quote character');
 });
 
-test('RFC 6265 disallowed characters in cookie-octet', function () {
+test('RFC 6265 - cookie-octet enclosed in DQUOTE', function () {
+	expect(1);
+	document.cookie = 'c="v"';
+	strictEqual(Cookies.get('c'), 'v', 'should decode the quotes');
+});
+
+test('RFC 6265 - cookie-octet with quotes enclosed in DQUOTE', function() {
+	expect(1);
+	document.cookie = 'c="with"quotes"';
+	strictEqual(Cookies.get('c'), 'with"quotes', 'should decode the quotes');
+});
+
+test('RFC 6265 - disallowed characters in cookie-octet', function () {
 	expect(5);
 
 	Cookies.set('whitespace', ' ');
@@ -248,7 +254,7 @@ test('RFC 6265 disallowed characters in cookie-octet', function () {
 	strictEqual(Cookies.get('multiple'), '" ,;\\" ,;\\', 'should handle multiple special characters');
 });
 
-test('RFC 6265 disallowed characters in cookie-name', function () {
+test('RFC 6265 - disallowed characters in cookie-name', function () {
 	expect(18);
 
 	Cookies.set('(', 'v');


### PR DESCRIPTION
@carhartl 

There's no mention of a slash to escape quotes in RFC 6265, is it safe to assume it's not going to be served from the server?
I am just expecting compliance from the server with `*cookie-octet / ( DQUOTE *cookie-octet DQUOTE )`. Opera doesn't allow plain quotes inside quoted cookie-value:

```shell
$ document.cookie = 'c="v"'
> 'c="v"'
$ document.cookie = 'c="v"2"'
> ''
```