### PR TITLE
Drop the Boolean return value of the "remove" method

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,9 +74,7 @@ Cookies.get(); // => { name: 'value' }
 Delete cookie:
 
 ```javascript
-// Returns true when cookie was successfully deleted, otherwise false
-Cookies.remove('name'); // => true
-Cookies.remove('nothing'); // => false
+Cookies.remove('name');
 
 // Need to use the same path, domain and secure attributes that were used when writing the cookie
 Cookies.set('name', 'value', { path: '/' });

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -132,9 +132,9 @@
 		api.defaults = {};
 
 		api.remove = function (key, options) {
-			// Must not alter options, thus extending a fresh object...
-			api(key, '', extend(options, { expires: -1 }));
-			return !api(key);
+			api(key, '', extend(options, {
+				expires: -1
+			}));
 		};
 
 		api.withConverter = init;

--- a/test/tests.js
+++ b/test/tests.js
@@ -164,24 +164,13 @@ test('defaults', function () {
 	ok(Cookies.set('c', 'v', { path: '/bar' }).match(/path=\/bar/), 'options argument has precedence');
 });
 
-module('removeCookie', lifecycle);
+module('remove', lifecycle);
 
 test('deletion', function () {
 	expect(1);
 	Cookies.set('c', 'v');
 	Cookies.remove('c');
 	strictEqual(document.cookie, '', 'should delete the cookie');
-});
-
-test('when sucessfully deleted', function () {
-	expect(1);
-	Cookies.set('c', 'v');
-	strictEqual(Cookies.remove('c'), true, 'returns true');
-});
-
-test('when cookie does not exist', function () {
-	expect(1);
-	strictEqual(Cookies.remove('c'), true, 'returns true');
 });
 
 test('with options', function () {


### PR DESCRIPTION
Now the "remove" method acts as void. If you need to check whether the cookie was removed or not, you can try to read it again:

```javascript
Cookies.remove('name');
if (!Cookies.get('name')) {
  // it was removed
}
```

Decided on https://github.com/js-cookie/js-cookie/pull/5#issuecomment-94297507