### PR TITLE
Add noConflict method to API

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,38 +34,38 @@ The plugin can also be loaded as AMD or CommonJS module.
 
 ## Usage
 
-Create session cookie:
+**Create session cookie:**
 
 ```javascript
 Cookies.set('name', 'value');
 ```
 
-Create expiring cookie, 7 days from then:
+**Create expiring cookie, 7 days from then:**
 
 ```javascript
 Cookies.set('name', 'value', { expires: 7 });
 ```
 
-Create expiring cookie, valid across entire site:
+**Create expiring cookie, valid across entire site:**
 
 ```javascript
 Cookies.set('name', 'value', { expires: 7, path: '/' });
 ```
 
-Read cookie:
+**Read cookie:**
 
 ```javascript
 Cookies.get('name'); // => "value"
 Cookies.get('nothing'); // => undefined
 ```
 
-Read all available cookies:
+**Read all available cookies:**
 
 ```javascript
 Cookies.get(); // => { "name": "value" }
 ```
 
-Delete cookie:
+**Delete cookie:**
 
 ```javascript
 // Returns true when cookie was successfully deleted, otherwise false
@@ -81,6 +81,20 @@ Cookies.remove('name', { path: '/' }); // => true
 ```
 
 *Note: when deleting a cookie, you must pass the exact same path, domain and secure options that were used to set the cookie, unless you're relying on the default options that is.*
+
+**Avoid namespace conflicts:**
+
+```javascript
+// Restore the Cookies namespace to its original value
+var NewCookies = Cookies.noConflict();
+NewCookies.set('name', 'value');
+```
+
+*If there is any danger of a conflict with the namespace `Cookies`, the
+`.noConflict` method will allow you define a new namespace and preserve the
+original namespace.*
+
+*This is especially useful when running the script on third party sites e.g. as part of a widget or SDK.*
 
 ## Configuration
 

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -23,6 +23,7 @@
 }(function ($) {
 
 	var pluses = /\+/g;
+	var _Cookies = (typeof(window) === 'undefined') ? void 0 : window.Cookies;
 
 	function encode(s) {
 		return api.raw ? s : encodeURIComponent(s);
@@ -131,6 +132,11 @@
 		// Must not alter options, thus extending a fresh object...
 		api(key, '', extend(options, { expires: -1 }));
 		return !api(key);
+	};
+
+	api.noConflict = function() {
+		Cookies = _Cookies;
+		return api;
 	};
 
 	if ( $ ) {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -4,5 +4,9 @@
 
 	"-W053": true,
 
-	"extends": "../.jshintrc"
+	"extends": "../.jshintrc",
+
+	"globals": {
+		"CookiesTemp": true
+	}
 }

--- a/test/index.html
+++ b/test/index.html
@@ -5,6 +5,7 @@
 		<title>JavaScript Cookie Test Suite</title>
 		<link href="http://code.jquery.com/qunit/qunit-1.14.0.css" rel="stylesheet">
 		<script src="http://code.jquery.com/qunit/qunit-1.14.0.js"></script>
+		<script>Cookies = 'foobar';</script>
 		<script src="../src/js.cookie.js"></script>
 		<script src="polyfill.js"></script>
 		<script src="tests.js"></script>

--- a/test/node.js
+++ b/test/node.js
@@ -1,13 +1,14 @@
 /*jshint node:true */
 exports.node = {
 	should_load_js_cookie: function(test) {
-		test.expect(3);
+		test.expect(4);
 		var Cookies = require('../src/js.cookie');
-		
+
 		test.ok( !!Cookies.get, 'should expose get api' );
 		test.ok( !!Cookies.set, 'should expose set api' );
 		test.ok( !!Cookies.remove, 'should expose remove api' );
-		
+		test.ok( !!Cookies.noConflict, 'should expose noConflict api' );
+
 		test.done();
 	}
 };

--- a/test/tests.js
+++ b/test/tests.js
@@ -362,3 +362,22 @@ test('read converter with raw = true', function() {
 	Cookies.set('c', '1');
 	strictEqual(Cookies.get('c', Number), 1, 'does not decode, but converts read value');
 });
+
+module('noConflict', {
+	teardown: function(){
+		Cookies = CookiesTemp;
+	}
+});
+
+test('returns Cookies api', function() {
+	expect(1);
+	CookiesTemp = Cookies.noConflict();
+	CookiesTemp.set('c', 'v');
+	strictEqual(CookiesTemp.get('c'), 'v', 'should write value');
+});
+
+test('restores original Cookies value', function() {
+	expect(1);
+	Cookies.noConflict();
+	strictEqual(Cookies, 'foobar', 'should restore original value');
+});


### PR DESCRIPTION
One issue with moving away from a jQuery plugin is that jQuery handles potential namespace conflicts very nicely using its `.noConflict` function.

Using `Cookies` as the namespace is fine if the script is being run on your own site. However if it needs to be run on a third party site, there is always the potential for namespace clashes, for example with [other cookie libraries](https://github.com/ScottHamper/Cookies) that also use `Cookies` as a namespace.

This adds a lightweight `.noConflict` method to the API, allowing the namespace to be reassigned and preserving the original value of `Cookies`.

The test suite and README are updated accordingly.