### PR TITLE
Rewrite browsers being tested in Sauce

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -83,89 +83,92 @@ module.exports = function (grunt) {
 					urls: ['http://127.0.0.1:9999'],
 					testname: 'Sauce Test for js-cookie',
 					build: process.env.TRAVIS_JOB_ID,
-					pollInterval: 5000,
-					browsers: [
-						// iOS
-						{
-							browserName: 'iphone',
-							platform: 'OS X 10.9',
-							version: '7.1'
-						},
-						{
-							browserName: 'ipad',
-							platform: 'OS X 10.9',
-							version: '7.1'
-						},
-						// Android
-						{
-							browserName: 'android',
-							platform: 'Linux',
-							version: '4.3'
-						},
-						// OS X
-						{
-							browserName: 'safari',
-							platform: 'OS X 10.9',
-							version: '7'
-						},
-						{
-							browserName: 'safari',
-							platform: 'OS X 10.8',
-							version: '6'
-						},
-						{
-							browserName: 'firefox',
-							platform: 'OS X 10.9',
-							version: '28'
-						},
-						// Windows
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 8.1',
-							version: '11'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 8',
-							version: '10'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 7',
-							version: '11'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 7',
-							version: '10'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 7',
-							version: '9'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 7',
-							version: '8'
-						},
-						{
-							browserName: 'firefox',
-							platform: 'Windows 7',
-							version: '29'
-						},
-						{
-							browserName: 'chrome',
-							platform: 'Windows 7',
-							version: '34'
-						},
-						// Linux
-						{
-							browserName: 'firefox',
-							platform: 'Linux',
-							version: '29'
+					pollInterval: 10000,
+					statusCheckAttempts: 90,
+					throttled: 3,
+					browsers: (function() {
+						var browsers = {
+							'iOS': [{
+								browserName: 'iphone',
+								platform: 'OS X 10.10',
+								version: '8.2',
+								deviceName: 'iPhone Simulator'
+							}, {
+								browserName: 'iphone',
+								platform: 'OS X 10.10',
+								version: '8.2',
+								deviceName: 'iPad Simulator'
+							}],
+							'android': [{
+								browserName: 'android',
+								platform: 'Linux',
+								version: '5.1',
+								deviceName: 'Android Emulator'
+							}],
+							'mac': [{
+								browserName: 'safari',
+								platform: 'OS X 10.10',
+								version: '8.0'
+							}, {
+								browserName: 'firefox',
+								platform: 'OS X 10.10',
+								version: '36.0'
+							}, {
+								browserName: 'chrome',
+								platform: 'OS X 10.10',
+								versiono: '41.0'
+							}],
+							'windows7': [{
+								browserName: 'internet explorer',
+								platform: 'Windows 7',
+								version: '11.0'
+							}, {
+								browserName: 'internet explorer',
+								platform: 'Windows 7',
+								version: '10.0'
+							}, {
+								browserName: 'internet explorer',
+								platform: 'Windows 7',
+								version: '9.0'
+							}, {
+								browserName: 'opera',
+								platform: 'Windows 7',
+								version: '12.12'
+							}],
+							'windowsXP': [{
+								browserName: 'internet explorer',
+								platform: 'Windows XP',
+								version: '8.0'
+							}, {
+								browserName: 'internet explorer',
+								platform: 'Windows XP',
+								version: '7.0'
+							}, {
+								browserName: 'internet explorer',
+								platform: 'Windows XP',
+								version: '6.0'
+							}],
+							'linux': [{
+								browserName: 'opera',
+								platform: 'Linux',
+								version: '12.15'
+							}, {
+								browserName: 'firefox',
+								platform: 'Linux',
+								version: '37.0'
+							}, {
+								browserName: 'chrome',
+								platform: 'Linux',
+								version: '41.0'
+							}]
+						};
+
+						var matrix = [];
+						for ( var os in browsers ) {
+							matrix = matrix.concat(browsers[os]);
 						}
-					]
+						return matrix;
+					}())
 				}
 			}
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -22,7 +22,7 @@ module.exports = function (grunt) {
 			},
 			grunt: 'Gruntfile.js',
 			source: 'src/**/*.js',
-			tests: 'test/**/*.js'
+			tests: ['test/**/*.js', '!test/polyfill.js']
 		},
 		uglify: {
 			options: {

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ Cookies.getJSON('name'); // => { foo: 'bar' }
 Cookies.getJSON(); // => { name: { foo: 'bar' } }
 ```
 
+**Note: To support IE6-8 you need to add the JSON-js polyfill: https://github.com/douglascrockford/JSON-js**
+
 ## Encoding
 
 This project is [RFC 6265](http://tools.ietf.org/html/rfc6265#section-4.1.1) compliant. All special characters that are not allowed in the cookie-name or cookie-value are encoded with each one's UTF-8 Hex equivalent.  

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Cookies.getJSON('name'); // => { foo: 'bar' }
 Cookies.getJSON(); // => { name: { foo: 'bar' } }
 ```
 
-**Note: To support IE6-8 you need to add the JSON-js polyfill: https://github.com/douglascrockford/JSON-js**
+*Note: To support IE6-8 you need to include the JSON-js polyfill: https://github.com/douglascrockford/JSON-js*
 
 ## Encoding
 

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -1,96 +1,11 @@
-// From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
-Object.keys = Object.keys || (function() {
-	'use strict';
-	var hasOwnProperty = Object.prototype.hasOwnProperty,
-			hasDontEnumBug = !({ toString: null }).propertyIsEnumerable('toString'),
-			dontEnums = [
-				'toString',
-				'toLocaleString',
-				'valueOf',
-				'hasOwnProperty',
-				'isPrototypeOf',
-				'propertyIsEnumerable',
-				'constructor'
-			],
-			dontEnumsLength = dontEnums.length;
+// Object.keys()
+// developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys
+Object.keys||(Object.keys=function(){"use strict";var a=Object.prototype.hasOwnProperty,b=!{toString:null}.propertyIsEnumerable("toString"),c=["toString","toLocaleString","valueOf","hasOwnProperty","isPrototypeOf","propertyIsEnumerable","constructor"],d=c.length;return function(e){if("object"!=typeof e&&("function"!=typeof e||null===e))throw new TypeError("Object.keys called on non-object");var g,h,f=[];for(g in e)a.call(e,g)&&f.push(g);if(b)for(h=0;d>h;h++)a.call(e,c[h])&&f.push(c[h]);return f}}());
 
-	return function(obj) {
-		if (typeof obj !== 'object' && (typeof obj !== 'function' || obj === null)) {
-			throw new TypeError('Object.keys called on non-object');
-		}
+// Array.forEach()
+// developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+Array.prototype.forEach||(Array.prototype.forEach=function(a,b){var c,d;if(null==this)throw new TypeError(" this is null or not defined");var e=Object(this),f=e.length>>>0;if("function"!=typeof a)throw new TypeError(a+" is not a function");for(arguments.length>1&&(c=b),d=0;f>d;){var g;d in e&&(g=e[d],a.call(c,g,d,e)),d++}});
 
-		var result = [], prop, i;
-
-		for (prop in obj) {
-			if (hasOwnProperty.call(obj, prop)) {
-				result.push(prop);
-			}
-		}
-
-		if (hasDontEnumBug) {
-			for (i = 0; i < dontEnumsLength; i++) {
-				if (hasOwnProperty.call(obj, dontEnums[i])) {
-					result.push(dontEnums[i]);
-				}
-			}
-		}
-		return result;
-	};
-}());
-
-// Reproducing steps of ECMA-262, Edition 5, 15.4.4.18
-// Reference: http://es5.github.com/#x15.4.4.18
-Array.prototype.forEach = Array.prototype.forEach || function( callback, thisArg ) {
-
-	var T, k;
-
-	if ( this === null || this === undefined ) {
-		throw new TypeError( "this is null or not defined" );
-	}
-
-	// 1. Let O be the result of calling ToObject passing the |this| value as the argument.
-	var O = Object(this);
-
-	// 2. Let lenValue be the result of calling the Get internal method of O with the argument
-	// "length".
-	// 3. Let len be ToUint32(lenValue).
-	var len = O.length >>> 0; // Hack to convert O.length to a UInt32
-
-	// 4. If IsCallable(callback) is false, throw a TypeError exception.
-	// See: http://es5.github.com/#x9.11
-	if ( {}.toString.call(callback) !== "[object Function]" ) {
-		throw new TypeError( callback + " is not a function" );
-	}
-
-	// 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
-	if ( thisArg ) {
-		T = thisArg;
-	}
-
-	// 6. Let k be 0
-	k = 0;
-
-	// 7. Repeat, while k < len
-	while( k < len ) {
-
-		var kValue;
-
-		// a. Let Pk be ToString(k).
-		//   This is implicit for LHS operands of the in operator
-		// b. Let kPresent be the result of calling the HasProperty internal method of O with argument Pk.
-		//   This step can be combined with c
-		// c. If kPresent is true, then
-		if ( Object.prototype.hasOwnProperty.call(O, k) ) {
-
-			// i. Let kValue be the result of calling the Get internal method of O with argument Pk.
-			kValue = O[ k ];
-	
-			// ii. Call the Call internal method of callback with T as the this value and
-			// argument list containing kValue, k, and O.
-			callback.call( T, kValue, k, O );
-		}
-		// d. Increase k by 1.
-		k++;
-	}
- // 8. return undefined
-};
+// JSON
+// github.com/douglascrockford/JSON-js/tree/c07c287e39ab5a1726818e0436490bf071b7c838
+"object"!=typeof JSON&&(JSON={}),function(){"use strict";function f(a){return 10>a?"0"+a:a}function this_value(){return this.valueOf()}function quote(a){return escapable.lastIndex=0,escapable.test(a)?'"'+a.replace(escapable,function(a){var b=meta[a];return"string"==typeof b?b:"\\u"+("0000"+a.charCodeAt(0).toString(16)).slice(-4)})+'"':'"'+a+'"'}function str(a,b){var c,d,e,f,h,g=gap,i=b[a];switch(i&&"object"==typeof i&&"function"==typeof i.toJSON&&(i=i.toJSON(a)),"function"==typeof rep&&(i=rep.call(b,a,i)),typeof i){case"string":return quote(i);case"number":return isFinite(i)?String(i):"null";case"boolean":case"null":return String(i);case"object":if(!i)return"null";if(gap+=indent,h=[],"[object Array]"===Object.prototype.toString.apply(i)){for(f=i.length,c=0;f>c;c+=1)h[c]=str(c,i)||"null";return e=0===h.length?"[]":gap?"[\n"+gap+h.join(",\n"+gap)+"\n"+g+"]":"["+h.join(",")+"]",gap=g,e}if(rep&&"object"==typeof rep)for(f=rep.length,c=0;f>c;c+=1)"string"==typeof rep[c]&&(d=rep[c],e=str(d,i),e&&h.push(quote(d)+(gap?": ":":")+e));else for(d in i)Object.prototype.hasOwnProperty.call(i,d)&&(e=str(d,i),e&&h.push(quote(d)+(gap?": ":":")+e));return e=0===h.length?"{}":gap?"{\n"+gap+h.join(",\n"+gap)+"\n"+g+"}":"{"+h.join(",")+"}",gap=g,e}}"function"!=typeof Date.prototype.toJSON&&(Date.prototype.toJSON=function(){return isFinite(this.valueOf())?this.getUTCFullYear()+"-"+f(this.getUTCMonth()+1)+"-"+f(this.getUTCDate())+"T"+f(this.getUTCHours())+":"+f(this.getUTCMinutes())+":"+f(this.getUTCSeconds())+"Z":null},Boolean.prototype.toJSON=this_value,Number.prototype.toJSON=this_value,String.prototype.toJSON=this_value);var cx,escapable,gap,indent,meta,rep;"function"!=typeof JSON.stringify&&(escapable=/[\\\"\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,meta={"\b":"\\b","	":"\\t","\n":"\\n","\f":"\\f","\r":"\\r",'"':'\\"',"\\":"\\\\"},JSON.stringify=function(a,b,c){var d;if(gap="",indent="","number"==typeof c)for(d=0;c>d;d+=1)indent+=" ";else"string"==typeof c&&(indent=c);if(rep=b,b&&"function"!=typeof b&&("object"!=typeof b||"number"!=typeof b.length))throw new Error("JSON.stringify");return str("",{"":a})}),"function"!=typeof JSON.parse&&(cx=/[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,JSON.parse=function(text,reviver){function walk(a,b){var c,d,e=a[b];if(e&&"object"==typeof e)for(c in e)Object.prototype.hasOwnProperty.call(e,c)&&(d=walk(e,c),void 0!==d?e[c]=d:delete e[c]);return reviver.call(a,b,e)}var j;if(text=String(text),cx.lastIndex=0,cx.test(text)&&(text=text.replace(cx,function(a){return"\\u"+("0000"+a.charCodeAt(0).toString(16)).slice(-4)})),/^[\],:{}\s]*$/.test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,"@").replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,"]").replace(/(?:^|:|,)(?:\s*\[)+/g,"")))return j=eval("("+text+")"),"function"==typeof reviver?walk({"":j},""):j;throw new SyntaxError("JSON.parse")})}();


### PR DESCRIPTION
I am not testing in all browsers and OS. I choose the ones that I believe create a very good statistical coverage of everything, it seems unnecessary and too time expensive to test in literally all browsers.

* Test in Android emulator, ignore other devices
* Test in iPhone and iPad emulators
* Test in Windows 7 for IE 9, 10, 11 and the latest version of Opera
* Test in Windows XP for IE 6, 7 and 8
* Test for all latest browser versions in Sauce for OS X Yosemite (ignore older OS)
* Test for all latest browser versions in Sauce for Linux, except Lynx

Ref #18.