### PR TITLE
Path default to '/'

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,12 +72,12 @@ Delete cookie:
 Cookies.remove('name');
 ```
 
-Delete cookie passing the attributes:
+Delete a cookie valid to the path of the current page:
 
 ```javascript
-Cookies.set('name', 'value', { path: '/foo' });
+Cookies.set('name', 'value', { path: '' });
 Cookies.remove('name'); // fail!
-Cookies.remove('name', { path: '/foo' }); // removed!
+Cookies.remove('name', { path: '' }); // removed!
 ```
 
 *IMPORTANT! when deleting a cookie, you must pass the exact same path, domain and secure attributes that were used to set the cookie, unless you're relying on the [default attributes](#cookie-attributes).*
@@ -159,9 +159,9 @@ Define the path where the cookie is available.
 **Examples:**
 
 ```javascript
-Cookies.set('name', 'value', { path: '/foo' });
+Cookies.set('name', 'value', { path: '' });
 Cookies.get('name'); // => 'value'
-Cookies.remove('name', { path: '/foo' });
+Cookies.remove('name', { path: '' });
 ```
 
 **Note regarding Internet Explorer:**

--- a/README.md
+++ b/README.md
@@ -35,22 +35,22 @@ It can also be loaded as an AMD or CommonJS module.
 
 ## Basic Usage
 
-Create a session cookie, valid to the path of the current page:
+Create a cookie, valid across the entire site:
 
 ```javascript
 Cookies.set('name', 'value');
 ```
 
-Create a cookie that expires 7 days from now, valid to the path of the current page:
+Create a cookie that expires 7 days from now, valid across the entire site:
 
 ```javascript
 Cookies.set('name', 'value', { expires: 7 });
 ```
 
-Create an expiring cookie, valid across the entire site:
+Create an expiring cookie, valid to the path of the current page:
 
 ```javascript
-Cookies.set('name', 'value', { expires: 7, path: '/' });
+Cookies.set('name', 'value', { expires: 7, path: '' });
 ```
 
 Read cookie:
@@ -72,9 +72,9 @@ Delete cookie:
 Cookies.remove('name');
 
 // Need to use the same path, domain and secure attributes that were used when writing the cookie
-Cookies.set('name', 'value', { path: '/' });
+Cookies.set('name', 'value', { path: '/foo' });
 Cookies.remove('name'); // fail!
-Cookies.remove('name', { path: '/' }); // removed!
+Cookies.remove('name', { path: '/foo' }); // removed!
 ```
 
 *IMPORTANT! when deleting a cookie, you must pass the exact same path, domain and secure attributes that were used to set the cookie, unless you're relying on the [default attributes](#cookie-attributes).*
@@ -137,7 +137,7 @@ Cookie attributes defaults can be set globally by setting properties of the `Coo
 
 Define when the cookie will be removed. Value can be a `Number` which will be interpreted as days from time of creation or a `Date` instance. If omitted, the cookie becomes a session cookie.
 
-**Browser default:** Cookie is removed when the user closes the browser.
+**Default:** Cookie is removed when the user closes the browser.
 
 **Examples:**
 
@@ -151,14 +151,14 @@ Cookies.remove('name');
 
 Define the path where the cookie is available.
 
-**Browser default:** Path of the page where the cookie was created
+**Default:** `/`
 
 **Examples:**
 
 ```javascript
-Cookies.set('name', 'value', { path: '/' });
+Cookies.set('name', 'value', { path: '/foo' });
 Cookies.get('name'); // => 'value'
-Cookies.remove('name', { path: '/' });
+Cookies.remove('name', { path: '/foo' });
 ```
 
 **Note regarding Internet Explorer:**
@@ -173,7 +173,7 @@ This means one cannot set a path using `path: window.location.pathname` in case 
 
 Define the domain where the cookie is available
 
-**Browser default:** Domain of the page where the cookie was created
+**Default:** Domain of the page where the cookie was created
 
 **Examples:**
 
@@ -186,7 +186,7 @@ Cookies.get('name'); // => undefined (need to read at 'sub.domain.com')
 
 A `Boolean` indicating if the cookie transmission requires a secure protocol (https)
 
-**Browser default:** No secure protocol requirement
+**Default:** No secure protocol requirement
 
 **Examples:**
 

--- a/README.md
+++ b/README.md
@@ -70,8 +70,11 @@ Delete cookie:
 
 ```javascript
 Cookies.remove('name');
+```
 
-// Need to use the same path, domain and secure attributes that were used when writing the cookie
+Delete cookie passing the attributes:
+
+```javascript
 Cookies.set('name', 'value', { path: '/foo' });
 Cookies.remove('name'); // fail!
 Cookies.remove('name', { path: '/foo' }); // removed!

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -23,29 +23,29 @@
 		var i = 0;
 		var result = {};
 		for (; i < arguments.length; i++) {
-			var options = arguments[ i ];
-			for (var key in options) {
-				result[key] = options[key];
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
 			}
 		}
 		return result;
 	}
 
 	function init (converter) {
-		function api (key, value, options) {
+		function api (key, value, attributes) {
 			var result;
 
 			// Write
 
 			if (arguments.length > 1) {
-				options = extend({
+				attributes = extend({
 					path: '/'
-				}, api.defaults, options);
+				}, api.defaults, attributes);
 
-				if (typeof options.expires === 'number') {
+				if (typeof attributes.expires === 'number') {
 					var expires = new Date();
-					expires.setMilliseconds(expires.getMilliseconds() + options.expires * 864e+5);
-					options.expires = expires;
+					expires.setMilliseconds(expires.getMilliseconds() + attributes.expires * 864e+5);
+					attributes.expires = expires;
 				}
 
 				try {
@@ -64,10 +64,10 @@
 
 				return (document.cookie = [
 					key, '=', value,
-					options.expires && '; expires=' + options.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
-					options.path    && '; path=' + options.path,
-					options.domain  && '; domain=' + options.domain,
-					options.secure  && '; secure'
+					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
+					attributes.path    && '; path=' + attributes.path,
+					attributes.domain  && '; domain=' + attributes.domain,
+					attributes.secure  && '; secure'
 				].join(''));
 			}
 
@@ -122,8 +122,8 @@
 		};
 		api.defaults = {};
 
-		api.remove = function (key, options) {
-			api(key, '', extend(options, {
+		api.remove = function (key, attributes) {
+			api(key, '', extend(attributes, {
 				expires: -1
 			}));
 		};

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -118,7 +118,9 @@
 				json: true
 			}, [].slice.call(arguments));
 		};
-		api.defaults = {};
+		api.defaults = {
+			path: '/'
+		};
 
 		api.remove = function (key, options) {
 			api(key, '', extend(options, {

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -38,7 +38,9 @@
 			// Write
 
 			if (arguments.length > 1) {
-				options = extend(api.defaults, options);
+				options = extend({
+					path: '/'
+				}, api.defaults, options);
 
 				if (typeof options.expires === 'number') {
 					var expires = new Date();
@@ -118,9 +120,7 @@
 				json: true
 			}, [].slice.call(arguments));
 		};
-		api.defaults = {
-			path: '/'
-		};
+		api.defaults = {};
 
 		api.remove = function (key, options) {
 			api(key, '', extend(options, {

--- a/test/tests.js
+++ b/test/tests.js
@@ -164,9 +164,15 @@ test('return value', function () {
 
 test('defaults', function () {
 	expect(2);
+
 	Cookies.defaults.path = '/foo';
-	ok(Cookies.set('c', 'v').match(/path=\/foo/), 'should use options from defaults');
-	ok(Cookies.set('c', 'v', { path: '/bar' }).match(/path=\/bar/), 'options argument has precedence');
+	ok(Cookies.set('c', 'v').match(/path=\/foo/), 'should use attributes from defaults');
+	Cookies.remove( 'c', { path: '/foo' });
+
+	ok(Cookies.set('c', 'v', { path: '/bar' }).match(/path=\/bar/), 'attributes argument has precedence');
+	Cookies.remove( 'c', { path: '/bar' });
+
+	delete Cookies.defaults.path;
 });
 
 module('remove', lifecycle);

--- a/test/tests.js
+++ b/test/tests.js
@@ -162,7 +162,12 @@ test('return value', function () {
 	strictEqual(actual, expected, 'should return written cookie string');
 });
 
-test('defaults', function () {
+test('default path attribute', function () {
+	expect(1);
+	ok(Cookies.set('c', 'v').match(/path=\//), 'should be default to the whole site');
+});
+
+test('changing defaults', function () {
 	expect(2);
 
 	Cookies.defaults.path = '/foo';

--- a/test/tests.js
+++ b/test/tests.js
@@ -157,7 +157,9 @@ test('expires option as Date instance', function () {
 
 test('return value', function () {
 	expect(1);
-	strictEqual(Cookies.set('c', 'v'), 'c=v', 'should return written cookie string');
+	var expected = 'c=v';
+	var actual = Cookies.set('c', 'v').substring(0, expected.length);
+	strictEqual(actual, expected, 'should return written cookie string');
 });
 
 test('defaults', function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -137,7 +137,8 @@ test('expires option as fraction of a day', function () {
 	expect(1);
 
 	var now = new Date().getTime();
-	var expires = Date.parse(Cookies.set('c', 'v', { expires: 0.5 }).replace(/.+expires=/, ''));
+	var stringifiedDate = Cookies.set('c', 'v', { expires: 0.5 }).split('; ')[1].split('=')[1];
+	var expires = Date.parse(stringifiedDate);
 
 	// When we were using Date.setDate() fractions have been ignored
 	// and expires resulted in the current date. Allow 1000 milliseconds

--- a/test/tests.js
+++ b/test/tests.js
@@ -184,20 +184,20 @@ test('deletion', function () {
 	strictEqual(document.cookie, '', 'should delete the cookie');
 });
 
-test('with options', function () {
+test('with attributes', function () {
 	expect(1);
-	var options = { path: '/' };
-	Cookies.set('c', 'v', options);
-	Cookies.remove('c', options);
+	var attributes = { path: '/' };
+	Cookies.set('c', 'v', attributes);
+	Cookies.remove('c', attributes);
 	strictEqual(document.cookie, '', 'should delete the cookie');
 });
 
-test('passing options reference', function () {
+test('passing attributes reference', function () {
 	expect(1);
-	var options = { path: '/' };
-	Cookies.set('c', 'v', options);
-	Cookies.remove('c', options);
-	deepEqual(options, { path: '/' }, 'won\'t alter options object');
+	var attributes = { path: '/' };
+	Cookies.set('c', 'v', attributes);
+	Cookies.remove('c', attributes);
+	deepEqual(attributes, { path: '/' }, 'won\'t alter attributes object');
 });
 
 module('converters', lifecycle);

--- a/test/tests.js
+++ b/test/tests.js
@@ -150,8 +150,9 @@ test('expires option as Date instance', function () {
 	expect(1);
 	var sevenDaysFromNow = new Date();
 	sevenDaysFromNow.setDate(sevenDaysFromNow.getDate() + 7);
-	strictEqual(Cookies.set('c', 'v', { expires: sevenDaysFromNow }), 'c=v; expires=' + sevenDaysFromNow.toUTCString(),
-		'should write the cookie string with expires');
+	var expected = 'c=v; expires=' + sevenDaysFromNow.toUTCString();
+	var actual = Cookies.set('c', 'v', { expires: sevenDaysFromNow }).substring(0, expected.length);
+	strictEqual(actual, expected, 'should write the cookie string with expires');
 });
 
 test('return value', function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -128,8 +128,9 @@ test('expires option as days from now', function () {
 	expect(1);
 	var sevenDaysFromNow = new Date();
 	sevenDaysFromNow.setDate(sevenDaysFromNow.getDate() + 21);
-	strictEqual(Cookies.set('c', 'v', { expires: 21 }), 'c=v; expires=' + sevenDaysFromNow.toUTCString(),
-		'should write the cookie string with expires');
+	var expected = 'c=v; expires=' + sevenDaysFromNow.toUTCString();
+	var actual = Cookies.set('c', 'v', { expires: 21 }).substring(0, expected.length);
+	strictEqual(actual, expected, 'should write the cookie string with expires');
 });
 
 test('expires option as fraction of a day', function () {

--- a/test/tests.js
+++ b/test/tests.js
@@ -220,7 +220,9 @@ test('should decode a malformed char that matches the decodeURIComponent regex',
 	document.cookie = 'c=%E3';
 	var cookies = Cookies.withConverter(unescape);
 	strictEqual(cookies.get('c'), 'ã', 'should convert the character correctly');
-	cookies.remove('c');
+	cookies.remove('c', {
+		path: ''
+	});
 });
 
 test('should be able to conditionally decode a single malformed cookie', function () {
@@ -230,6 +232,7 @@ test('should be able to conditionally decode a single malformed cookie', functio
 			return unescape(value);
 		}
 	});
+
 	document.cookie = 'escaped=%u5317';
 	strictEqual(cookies.get('escaped'), '北', 'should use a custom method for escaped cookie');
 
@@ -241,7 +244,11 @@ test('should be able to conditionally decode a single malformed cookie', functio
 		encoded: '京'
 	}, 'should retrieve everything');
 
-	Object.keys(cookies.get()).forEach(cookies.remove);
+	Object.keys(cookies.get()).forEach(function (name) {
+		cookies.remove(name, {
+			path: ''
+		});
+	});
 	strictEqual(document.cookie, '', 'should remove everything');
 });
 
@@ -320,4 +327,3 @@ test('do not conflict with existent globals', function () {
 	strictEqual(window.Cookies, 'existent global', 'should restore the original global');
 	window.Cookies = Cookies;
 });
-

--- a/test/tests.js
+++ b/test/tests.js
@@ -164,11 +164,11 @@ test('return value', function () {
 
 test('default path attribute', function () {
 	expect(1);
-	ok(Cookies.set('c', 'v').match(/path=\//), 'should be default to the whole site');
+	ok(Cookies.set('c', 'v').match(/path=\//), 'should read the default path');
 });
 
-test('changing defaults', function () {
-	expect(2);
+test('API for changing defaults', function () {
+	expect(3);
 
 	Cookies.defaults.path = '/foo';
 	ok(Cookies.set('c', 'v').match(/path=\/foo/), 'should use attributes from defaults');
@@ -178,6 +178,7 @@ test('changing defaults', function () {
 	Cookies.remove( 'c', { path: '/bar' });
 
 	delete Cookies.defaults.path;
+	ok(Cookies.set('c', 'v').match(/path=\//), 'should roll back to the default path');
 });
 
 module('remove', lifecycle);

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,7 +34,6 @@
 
 	window.lifecycle = {
 		teardown: function () {
-			Cookies.defaults = {};
 			Object.keys(Cookies.get()).forEach(Cookies.remove);
 		}
 	};

--- a/test/utils.js
+++ b/test/utils.js
@@ -34,7 +34,14 @@
 
 	window.lifecycle = {
 		teardown: function () {
+			// Remove the cookies created using js-cookie default attributes
 			Object.keys(Cookies.get()).forEach(Cookies.remove);
+			// Remove the cookies created using browser default attributes
+			Object.keys(Cookies.get()).forEach(function (cookie) {
+				Cookies.remove(cookie, {
+					path: ''
+				});
+			});
 		}
 	};
 }());


### PR DESCRIPTION
Refers to #25.

Consider I am reading the cookie from the server:

```javascript
document.cookie = 'c=v';
```

To remove it using `js-cookie`, the first thing one would try to do is this:

```javascript
Cookies.remove('c');
```

But it doesn't work (in PhantomJS). `js-cookie` is trying to remove the cookie using the `js-cookie` custom default attribute `path: '/'`. To be able to remove it successfully, one should pass the custom attribute to the `remove` function or change the defaults:

```javascript
Cookies.remove('c', {
  path: ''
});
```

```javascript
Cookies.defaults.path = '';
Cookies.remove('c');
```

If after altering the defaults one wants to roll back to `js-cookie` defaults (not browsers defaults), then it's just to delete the custom property from the `defaults` like this:

```javascript
delete Cookies.defaults.path;
```

Then it will consider the default path attribute to `/` for set/get/remove operations.

It is a little confusing when dealing with cookies from the server, but if you deal with cookies only through `js-cookie` or one of it's [available language ports](https://github.com/js-cookie), then it is just a matter of declaring what you want to do without worring about any additional configuration:

```javascript
Cookies.set('c', 'v'); // default: "path: /"
Cookies.remove('c'); // removed successfully using default: "path: /"
```

Key commits: https://github.com/js-cookie/js-cookie/commit/bc4b822a98b580367f21329711c8d8474c0181e5, https://github.com/js-cookie/js-cookie/commit/38dc9e2b0e2300b773869e2ec82b4a40eef3cb09

![image](https://cloud.githubusercontent.com/assets/835857/7439371/a4a2d81a-f04e-11e4-83f8-296e6fe13fec.png)
