### PR TITLE
Remove use of deprecated ‘escape’ function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,6 @@ node_modules
 build
 .sizecache.json
 *.log*
+# Eclipse project files
+/.settings/
+/.project

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -60,7 +60,7 @@
 
 				key = encodeURIComponent(String(key));
 				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
-				key = key.replace(/[\(\)]/g, escape);
+				key = key.replace(/[()]/g, function (s) { return '%' + s.charCodeAt(0).toString(16); });
 
 				return (document.cookie = [
 					key, '=', value,

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -50,7 +50,7 @@
 
 				try {
 					result = JSON.stringify(value);
-					if (/^[\{\[]/.test(result)) {
+					if (/^[{[]/.test(result)) {
 						value = result;
 					}
 				} catch (e) {}


### PR DESCRIPTION
According to MDN, [escape](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/escape) is deprecated and should not be used.

I have replaced it with a lambda function. To somewhat reduce the increase in code size, I have also removed a few unnecessary backslashes from RegEx.