### PR TITLE
Make it possible to test the encoding from server-side

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,8 +66,8 @@ After the test suite has finished, js-cookie exposes the global `window.global_t
 
 When js-cookie encoding tests are executed, it will request a url in the server through an iframe representing each test being run. js-cookie expects the server to handle the input and return the proper `Set-Cookie` headers in the response. js-cookie will then read the response and verify if the encoding is consistent with js-cookie default encoding mechanism
 
-js-cookie will send some requests to the server from the baseurl in the format `/encoding/<cookie>`, where `<cookie>` represents the cookie-name to be read from the request.
+js-cookie will send some requests to the server from the baseurl in the format `/encoding?name=<cookie>`, where `<cookie>` represents the cookie-name to be read from the request.
 
-The server should handle those requests, internally parsing the cookie and writing it again. It must set an `application/json` content type containing an object literal in the content body with `name` and `value` keys, each representing the cookie-name and the cookie-value respectively.
+The server should handle those requests, internally parsing the cookie from the request and writing it again. It must set an `application/json` content type containing an object literal in the content body with `name` and `value` keys, each representing the cookie-name and the cookie-value respectively.
 
 If the server fails to respond with this specification in any request, the related QUnit test will fail. This is to make sure the server-side implementation will always be in sync with js-cookie encoding tests for maximum compatibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -68,6 +68,6 @@ When js-cookie encoding tests are executed, it will request a url in the server 
 
 js-cookie will send some requests to the server from the baseurl in the format `/encoding?name=<cookie>`, where `<cookie>` represents the cookie-name to be read from the request.
 
-The server should handle those requests, internally parsing the cookie from the request and writing it again. It must set an `application/json` content type containing an object literal in the content body with `name` and `value` keys, each representing the cookie-name and the cookie-value respectively.
+The server should handle those requests, internally parsing the cookie from the request and writing it again. It must set an `application/json` content type containing an object literal in the content body with `name` and `value` keys, each representing the cookie-name and cookie-value decoded by the server-side implementation.
 
 If the server fails to respond with this specification in any request, the related QUnit test will fail. This is to make sure the server-side implementation will always be in sync with js-cookie encoding tests for maximum compatibility.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,23 +1,23 @@
-##Issues
+## Issues
 
 - Report issues or feature requests on [GitHub Issues](https://github.com/js-cookie/js-cookie/issues).
 - If reporting a bug, please add a [simplified example](http://sscce.org/).
 
-##Pull requests
+## Pull requests
 - Create a new topic branch for every separate change you make.
 - Create a test case if you are fixing a bug or implementing an important feature.
 - Make sure the build runs successfully.
 
 ## Development
 
-###Tools
+### Tools
 We use the following tools for development:
 
 - [Qunit](http://qunitjs.com/) for tests.
 - [NodeJS](http://nodejs.org/download/) required to run grunt.
 - [Grunt](http://gruntjs.com/getting-started) for task management.
 
-###Getting started 
+### Getting started 
 Install [NodeJS](http://nodejs.org/).  
 Install globally grunt-cli using the following command:
 
@@ -35,7 +35,7 @@ You should see a green message in the console:
 
     Done, without errors.
 
-###Tests
+### Tests
 You can also run the tests in the browser.  
 Start a test server from the project root:
 
@@ -45,7 +45,29 @@ This will automatically open the test suite at http://127.0.0.1:10000 in the def
 
 _Note: we recommend cleaning all the browser cookies before running the tests, that can avoid false positive failures._
 
-###Automatic build
+### Automatic build
 You can build automatically after a file change using the following command:
 
     $ grunt watch
+
+## Integration with server-side
+
+js-cookie allows integrating the encoding test suite with solutions written in other server-side languages. To integrate successfully, the server-side solution need to execute the `test/encoding.html` file in it's integration testing routine with a web automation tool, like [Selenium](http://www.seleniumhq.org/). js-cookie test suite exposes an API to make this happen.
+
+### ?integration_baseurl
+
+Specify the base url to pass the cookies into the server through a query string. If `integration_baseurl` query is not present, then js-cookie will assume there's no server.
+
+### window.global_test_results
+
+After the test suite has finished, js-cookie exposes the global `window.global_test_results` property containing an Object Literal that represents the [QUnit's details](http://api.qunitjs.com/QUnit.done/). js-cookie also adds an additional property representing an Array containing the tests data.
+
+### Handling requests
+
+When js-cookie encoding tests are executed, it will request a url in the server through an iframe representing each test being run. js-cookie expects the server to handle the input and return the proper `Set-Cookie` headers in the response. js-cookie will then read the response and verify if the encoding is consistent with js-cookie default encoding mechanism
+
+js-cookie will send some requests to the server from the baseurl in the format `/encoding/<cookie>`, where `<cookie>` represents the cookie-name to be read from the request.
+
+The server should handle those requests, internally parsing the cookie and writing it again. It must set an `application/json` content type containing an object literal in the content body with `name` and `value` keys, each representing the cookie-name and the cookie-value respectively.
+
+If the server fails to respond with this specification in any request, the related QUnit test will fail. This is to make sure the server-side implementation will always be in sync with js-cookie encoding tests for maximum compatibility.

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -3,15 +3,38 @@
 
 module.exports = function (grunt) {
 
+	function encodingMiddleware(request, response, next) {
+		var url = require('url').parse(request.url, true, true);
+		var query = url.query;
+		var pathname = url.pathname;
+
+		if (pathname !== '/encoding') {
+			next();
+			return;
+		}
+
+		var cookieName = query.name;
+		var cookieValue = query.value;
+
+		response.setHeader('content-type', 'application/json');
+		response.end(JSON.stringify({
+			name: cookieName,
+			value: cookieValue
+		}));
+	}
+
 	grunt.initConfig({
 		pkg: grunt.file.readJSON('package.json'),
 		qunit: {
 			all: {
 				options: {
-					httpBase: 'http://127.0.0.1:9998'
-				},
-				src: ['test/index.html', 'test/encoding.html', 'test/amd.html']
-			}
+					urls: [
+						'http://127.0.0.1:9998/',
+						'http://127.0.0.1:9998/amd.html',
+						'http://127.0.0.1:9998/encoding.html?integration_baseurl=http://127.0.0.1:9998'
+					]
+				}
+			},
 		},
 		nodeunit: {
 			all: 'test/node.js'
@@ -76,15 +99,19 @@ module.exports = function (grunt) {
 			}
 		},
 		connect: {
-			'build-sauce': {
-				options: {
-					port: 9999,
-					base: ['.', 'test']
-				}
-			},
 			'build-qunit': {
 				options: {
 					port: 9998,
+					base: ['.', 'test'],
+					middleware: function (connect, options, middlewares) {
+						middlewares.unshift(encodingMiddleware);
+						return middlewares;
+					}
+				}
+			},
+			'build-sauce': {
+				options: {
+					port: 9999,
 					base: ['.', 'test']
 				}
 			},
@@ -94,7 +121,11 @@ module.exports = function (grunt) {
 					base: ['.', 'test'],
 					open: 'http://127.0.0.1:10000',
 					keepalive: true,
-					livereload: true
+					livereload: true,
+					middleware: function (connect, options, middlewares) {
+						middlewares.unshift(encodingMiddleware);
+						return middlewares;
+					}
 				}
 			}
 		},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,7 +31,7 @@ module.exports = function (grunt) {
 					urls: [
 						'http://127.0.0.1:9998/',
 						'http://127.0.0.1:9998/amd.html',
-						'http://127.0.0.1:9998/encoding.html?integration_baseurl=http://127.0.0.1:9998'
+						'http://127.0.0.1:9998/encoding.html?integration_baseurl=http://127.0.0.1:9998/'
 					]
 				}
 			},

--- a/bower.json
+++ b/bower.json
@@ -3,13 +3,5 @@
   "version": "2.0.0-pre",
   "main": [
     "src/js.cookie.js"
-  ],
-  "ignore": [
-    "test",
-    ".*",
-    "*.json",
-    "*.md",
-    "*.txt",
-    "Gruntfile.js"
   ]
 }

--- a/bower.json
+++ b/bower.json
@@ -3,5 +3,6 @@
   "version": "2.0.0-pre",
   "main": [
     "src/js.cookie.js"
-  ]
+  ],
+  "ignore": []
 }

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -7,6 +7,9 @@
 	"extends": "../.jshintrc",
 	"globals": {
 		"require": true,
-		"unescape": true
+		"unescape": true,
+		"lifecycle": true,
+		"using": true,
+		"addEvent": true
 	}
 }

--- a/test/encoding.html
+++ b/test/encoding.html
@@ -11,6 +11,8 @@
 	</head>
 	<body>
 		<div id="qunit"></div>
-		<div id="qunit-fixture"></div>
+		<div id="qunit-fixture">
+			<iframe id="request_target"></iframe>
+		</div>
 	</body>
 </html>

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,5 +1,3 @@
-/*global lifecycle: true*/
-
 QUnit.module('cookie-value', lifecycle);
 
 QUnit.test('cookie-value with double quotes', function (assert) {
@@ -22,423 +20,600 @@ QUnit.test('cookie-value with double quotes in the right', function (assert) {
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-value " "', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', ' ');
-	assert.strictEqual(Cookies.get('c'), ' ', 'should handle the whitespace character');
-	assert.strictEqual(document.cookie, 'c=%20', 'whitespace is not allowed, need to encode');
+	using(assert)
+	.setCookie('c', ' ')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, ' ', 'should handle the whitespace character');
+		assert.strictEqual(plainValue, 'c=%20', 'whitespace is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-value ","', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', ',');
-	assert.strictEqual(Cookies.get('c'), ',', 'should handle the comma character');
-	assert.strictEqual(document.cookie, 'c=%2C', 'comma is not allowed, need to encode');
+	using(assert)
+	.setCookie('c', ',')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, ',', 'should handle the comma character');
+		assert.strictEqual(plainValue, 'c=%2C', 'comma is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-value ";"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', ';');
-	assert.strictEqual(Cookies.get('c'), ';', 'should handle the semicolon character');
-	assert.strictEqual(document.cookie, 'c=%3B', 'semicolon is not allowed, need to encode');
+	using(assert)
+	.setCookie('c', ';')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, ';', 'should handle the semicolon character');
+		assert.strictEqual(plainValue, 'c=%3B', 'semicolon is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-value "\\"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '\\');
-	assert.strictEqual(Cookies.get('c'), '\\', 'should handle the backslash character');
-	assert.strictEqual(document.cookie, 'c=%5C', 'backslash is not allowed, need to encode');
+	using(assert)
+	.setCookie('c', '\\')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '\\', 'should handle the backslash character');
+		assert.strictEqual(plainValue, 'c=%5C', 'backslash is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - characters not allowed in the cookie-value should be replaced globally', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', ';;');
-	assert.strictEqual(Cookies.get('c'), ';;', 'should handle multiple not allowed characters');
-	assert.strictEqual(document.cookie, 'c=%3B%3B', 'should replace multiple not allowed characters');
+	using(assert)
+	.setCookie('c', ';;')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, ';;', 'should handle multiple not allowed characters');
+		assert.strictEqual(plainValue, 'c=%3B%3B', 'should replace multiple not allowed characters');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "#"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '#');
-	assert.strictEqual(Cookies.get('c'), '#', 'should handle the sharp character');
-	assert.strictEqual(document.cookie, 'c=#', 'sharp is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '#')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '#', 'should handle the sharp character');
+		assert.strictEqual(plainValue, 'c=#', 'sharp is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "$"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '$');
-	assert.strictEqual(Cookies.get('c'), '$', 'should handle the dollar sign character');
-	assert.strictEqual(document.cookie, 'c=$', 'dollar sign is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '$')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '$', 'should handle the dollar sign character');
+		assert.strictEqual(plainValue, 'c=$', 'dollar sign is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "%"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '%');
-	assert.strictEqual(Cookies.get('c'), '%', 'should handle the percent character');
-	assert.strictEqual(document.cookie, 'c=%25', 'percent is allowed, but need to be escaped');
+	using(assert)
+	.setCookie('c', '%')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '%', 'should handle the percent character');
+		assert.strictEqual(plainValue, 'c=%25', 'percent is allowed, but need to be escaped');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "&"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '&');
-	assert.strictEqual(Cookies.get('c'), '&', 'should handle the ampersand character');
-	assert.strictEqual(document.cookie, 'c=&', 'ampersand is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '&')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '&', 'should handle the ampersand character');
+		assert.strictEqual(plainValue, 'c=&', 'ampersand is allowed, should not encode');
+	});
 });
 
 // github.com/carhartl/jquery-cookie/pull/62
 QUnit.test('RFC 6265 - character allowed in the cookie-value "+"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '+');
-	assert.strictEqual(Cookies.get('c'), '+', 'should handle the plus character');
-	assert.strictEqual(document.cookie, 'c=+', 'plus is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '+')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '+', 'should handle the plus character');
+		assert.strictEqual(plainValue, 'c=+', 'plus is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value ":"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', ':');
-	assert.strictEqual(Cookies.get('c'), ':', 'should handle the colon character');
-	assert.strictEqual(document.cookie, 'c=:', 'colon is allowed, should not encode');
+	using(assert)
+	.setCookie('c', ':')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, ':', 'should handle the colon character');
+		assert.strictEqual(plainValue, 'c=:', 'colon is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "<"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '<');
-	assert.strictEqual(Cookies.get('c'), '<', 'should handle the less-than character');
-	assert.strictEqual(document.cookie, 'c=<', 'less-than is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '<')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '<', 'should handle the less-than character');
+		assert.strictEqual(plainValue, 'c=<', 'less-than is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value ">"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '>');
-	assert.strictEqual(Cookies.get('c'), '>', 'should handle the greater-than character');
-	assert.strictEqual(document.cookie, 'c=>', 'greater-than is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '>')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '>', 'should handle the greater-than character');
+		assert.strictEqual(plainValue, 'c=>', 'greater-than is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "="', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '=');
-	assert.strictEqual(Cookies.get('c'), '=', 'should handle the equal sign character');
-	assert.strictEqual(document.cookie, 'c==', 'equal sign is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '=')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '=', 'should handle the equal sign character');
+		assert.strictEqual(plainValue, 'c==', 'equal sign is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "/"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '/');
-	assert.strictEqual(Cookies.get('c'), '/', 'should handle the slash character');
-	assert.strictEqual(document.cookie, 'c=/', 'slash is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '/')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '/', 'should handle the slash character');
+		assert.strictEqual(plainValue, 'c=/', 'slash is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "?"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '?');
-	assert.strictEqual(Cookies.get('c'), '?', 'should handle the question mark character');
-	assert.strictEqual(document.cookie, 'c=?', 'question mark is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '?')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '?', 'should handle the question mark character');
+		assert.strictEqual(plainValue, 'c=?', 'question mark is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "@"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '@');
-	assert.strictEqual(Cookies.get('c'), '@', 'should handle the at character');
-	assert.strictEqual(document.cookie, 'c=@', 'at is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '@')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '@', 'should handle the at character');
+		assert.strictEqual(plainValue, 'c=@', 'at is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "["', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '[');
-	assert.strictEqual(Cookies.get('c'), '[', 'should handle the opening square bracket character');
-	assert.strictEqual(document.cookie, 'c=[', 'opening square bracket is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '[')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '[', 'should handle the opening square bracket character');
+		assert.strictEqual(plainValue, 'c=[', 'opening square bracket is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "]"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', ']');
-	assert.strictEqual(Cookies.get('c'), ']', 'should handle the closing square bracket character');
-	assert.strictEqual(document.cookie, 'c=]', 'closing square bracket is allowed, should not encode');
+	using(assert)
+	.setCookie('c', ']')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, ']', 'should handle the closing square bracket character');
+		assert.strictEqual(plainValue, 'c=]', 'closing square bracket is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "^"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '^');
-	assert.strictEqual(Cookies.get('c'), '^', 'should handle the caret character');
-	assert.strictEqual(document.cookie, 'c=^', 'caret is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '^')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '^', 'should handle the caret character');
+		assert.strictEqual(plainValue, 'c=^', 'caret is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "`"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '`');
-	assert.strictEqual(Cookies.get('c'), '`', 'should handle the grave accent character');
-	assert.strictEqual(document.cookie, 'c=`', 'grave accent is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '`')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '`', 'should handle the grave accent character');
+		assert.strictEqual(plainValue, 'c=`', 'grave accent is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "{"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '{');
-	assert.strictEqual(Cookies.get('c'), '{', 'should handle the opening curly bracket character');
-	assert.strictEqual(document.cookie, 'c={', 'opening curly bracket is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '{')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '{', 'should handle the opening curly bracket character');
+		assert.strictEqual(plainValue, 'c={', 'opening curly bracket is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "}"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '}');
-	assert.strictEqual(Cookies.get('c'), '}', 'should handle the closing curly bracket character');
-	assert.strictEqual(document.cookie, 'c=}', 'closing curly bracket is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '}')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '}', 'should handle the closing curly bracket character');
+		assert.strictEqual(plainValue, 'c=}', 'closing curly bracket is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-value "|"', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '|');
-	assert.strictEqual(Cookies.get('c'), '|', 'should handle the pipe character');
-	assert.strictEqual(document.cookie, 'c=|', 'pipe is allowed, should not encode');
+	using(assert)
+	.setCookie('c', '|')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '|', 'should handle the pipe character');
+		assert.strictEqual(plainValue, 'c=|', 'pipe is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - characters allowed in the cookie-value should globally not be encoded', function (assert) {
 	assert.expect(1);
-	Cookies.set('c', '{{');
-	assert.strictEqual(document.cookie, 'c={{', 'should not encode all the character occurrences');
+	using(assert)
+	.setCookie('c', '{{')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(plainValue, 'c={{', 'should not encode all the character occurrences');
+	});
 });
 
 QUnit.test('cookie-value - 2 bytes character (ã)', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', 'ã');
-	assert.strictEqual(Cookies.get('c'), 'ã', 'should handle the ã character');
-	assert.strictEqual(document.cookie, 'c=%C3%A3', 'should encode the ã character');
+	using(assert)
+	.setCookie('c', 'ã')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'ã', 'should handle the ã character');
+		assert.strictEqual(plainValue, 'c=%C3%A3', 'should encode the ã character');
+	});
 });
 
 QUnit.test('cookie-value - 3 bytes character (₯)', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '₯');
-	assert.strictEqual(Cookies.get('c'), '₯', 'should handle the ₯ character');
-	assert.strictEqual(document.cookie, 'c=%E2%82%AF', 'should encode the ₯ character');
+	using(assert)
+	.setCookie('c', '₯')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '₯', 'should handle the ₯ character');
+		assert.strictEqual(plainValue, 'c=%E2%82%AF', 'should encode the ₯ character');
+	});
 });
 
 QUnit.test('cookie-value - 4 bytes character (𩸽)', function (assert) {
 	assert.expect(2);
-	Cookies.set('c', '𩸽');
-	assert.strictEqual(Cookies.get('c'), '𩸽', 'should handle the 𩸽 character');
-	assert.strictEqual(document.cookie, 'c=%F0%A9%B8%BD', 'should encode the 𩸽 character');
+	using(assert)
+	.setCookie('c', '𩸽')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, '𩸽', 'should handle the 𩸽 character');
+		assert.strictEqual(plainValue, 'c=%F0%A9%B8%BD', 'should encode the 𩸽 character');
+	});
 });
 
 QUnit.module('cookie-name', lifecycle);
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "("', function (assert) {
 	assert.expect(2);
-	Cookies.set('(', 'v');
-	assert.strictEqual(Cookies.get('('), 'v', 'should handle the opening parens character');
-	assert.strictEqual(document.cookie, '%28=v', 'opening parens is not allowed, need to encode');
+	using(assert)
+	.setCookie('(', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the opening parens character');
+		assert.strictEqual(plainValue, '%28=v', 'opening parens is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name ")"', function (assert) {
 	assert.expect(2);
-	Cookies.set(')', 'v');
-	assert.strictEqual(Cookies.get(')'), 'v', 'should handle the closing parens character');
-	assert.strictEqual(document.cookie, '%29=v', 'closing parens is not allowed, need to encode');
+	using(assert)
+	.setCookie(')', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the closing parens character');
+		assert.strictEqual(plainValue, '%29=v', 'closing parens is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - should replace parens globally', function (assert) {
 	assert.expect(1);
-	Cookies.set('(())', 'v');
-	assert.strictEqual(document.cookie, '%28%28%29%29=v', 'encode with global replace');
+	using(assert)
+	.setCookie('(())', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(plainValue, '%28%28%29%29=v', 'encode with global replace');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "<"', function (assert) {
 	assert.expect(2);
-	Cookies.set('<', 'v');
-	assert.strictEqual(Cookies.get('<'), 'v', 'should handle the less-than character');
-	assert.strictEqual(document.cookie, '%3C=v', 'less-than is not allowed, need to encode');
+	using(assert)
+	.setCookie('<', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the less-than character');
+		assert.strictEqual(plainValue, '%3C=v', 'less-than is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name ">"', function (assert) {
 	assert.expect(2);
-	Cookies.set('>', 'v');
-	assert.strictEqual(Cookies.get('>'), 'v', 'should handle the greater-than character');
-	assert.strictEqual(document.cookie, '%3E=v', 'greater-than is not allowed, need to encode');
+	using(assert)
+	.setCookie('>', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the greater-than character');
+		assert.strictEqual(plainValue, '%3E=v', 'greater-than is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "@"', function (assert) {
 	assert.expect(2);
-	Cookies.set('@', 'v');
-	assert.strictEqual(Cookies.get('@'), 'v', 'should handle the at character');
-	assert.strictEqual(document.cookie, '%40=v', 'at is not allowed, need to encode');
+	using(assert)
+	.setCookie('@', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the at character');
+		assert.strictEqual(plainValue, '%40=v', 'at is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name ","', function (assert) {
 	assert.expect(2);
-	Cookies.set(',', 'v');
-	assert.strictEqual(Cookies.get(','), 'v', 'should handle the comma character');
-	assert.strictEqual(document.cookie, '%2C=v', 'comma is not allowed, need to encode');
+	using(assert)
+	.setCookie(',', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the comma character');
+		assert.strictEqual(plainValue, '%2C=v', 'comma is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name ";"', function (assert) {
 	assert.expect(2);
-	Cookies.set(';', 'v');
-	assert.strictEqual(Cookies.get(';'), 'v', 'should handle the semicolon character');
-	assert.strictEqual(document.cookie, '%3B=v', 'semicolon is not allowed, need to encode');
+	using(assert)
+	.setCookie(';', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the semicolon character');
+		assert.strictEqual(plainValue, '%3B=v', 'semicolon is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name ":"', function (assert) {
 	assert.expect(2);
-	Cookies.set(':', 'v');
-	assert.strictEqual(Cookies.get(':'), 'v', 'should handle the colon character');
-	assert.strictEqual(document.cookie, '%3A=v', 'colon is not allowed, need to encode');
+	using(assert)
+	.setCookie(':', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the colon character');
+		assert.strictEqual(plainValue, '%3A=v', 'colon is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "\\"', function (assert) {
 	assert.expect(2);
-	Cookies.set('\\', 'v');
-	assert.strictEqual(Cookies.get('\\'), 'v', 'should handle the backslash character');
-	assert.strictEqual(document.cookie, '%5C=v', 'backslash is not allowed, need to encode');
+	using(assert)
+	.setCookie('\\', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the backslash character');
+		assert.strictEqual(plainValue, '%5C=v', 'backslash is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "\""', function (assert) {
 	assert.expect(2);
-	Cookies.set('"', 'v');
-	assert.strictEqual(Cookies.get('"'), 'v', 'should handle the double quote character');
-	assert.strictEqual(document.cookie, '%22=v', 'double quote is not allowed, need to encode');
+	using(assert)
+	.setCookie('"', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the double quote character');
+		assert.strictEqual(plainValue, '%22=v', 'double quote is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "/"', function (assert) {
 	assert.expect(2);
-	Cookies.set('/', 'v');
-	assert.strictEqual(Cookies.get('/'), 'v', 'should handle the slash character');
-	assert.strictEqual(document.cookie, '%2F=v', 'slash is not allowed, need to encode');
+	using(assert)
+	.setCookie('/', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the slash character');
+		assert.strictEqual(plainValue, '%2F=v', 'slash is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "["', function (assert) {
 	assert.expect(2);
-	Cookies.set('[', 'v');
-	assert.strictEqual(Cookies.get('['), 'v', 'should handle the opening square brackets character');
-	assert.strictEqual(document.cookie, '%5B=v', 'opening square brackets is not allowed, need to encode');
+	using(assert)
+	.setCookie('[', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the opening square brackets character');
+		assert.strictEqual(plainValue, '%5B=v', 'opening square brackets is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "]"', function (assert) {
 	assert.expect(2);
-	Cookies.set(']', 'v');
-	assert.strictEqual(Cookies.get(']'), 'v', 'should handle the closing square brackets character');
-	assert.strictEqual(document.cookie, '%5D=v', 'closing square brackets is not allowed, need to encode');
+	using(assert)
+	.setCookie(']', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the closing square brackets character');
+		assert.strictEqual(plainValue, '%5D=v', 'closing square brackets is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "?"', function (assert) {
 	assert.expect(2);
-	Cookies.set('?', 'v');
-	assert.strictEqual(Cookies.get('?'), 'v', 'should handle the question mark character');
-	assert.strictEqual(document.cookie, '%3F=v', 'question mark is not allowed, need to encode');
+	using(assert)
+	.setCookie('?', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the question mark character');
+		assert.strictEqual(plainValue, '%3F=v', 'question mark is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "="', function (assert) {
 	assert.expect(2);
-	Cookies.set('=', 'v');
-	assert.strictEqual(Cookies.get('='), 'v', 'should handle the equal sign character');
-	assert.strictEqual(document.cookie, '%3D=v', 'equal sign is not allowed, need to encode');
+	using(assert)
+	.setCookie('=', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the equal sign character');
+		assert.strictEqual(plainValue, '%3D=v', 'equal sign is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "{"', function (assert) {
 	assert.expect(2);
-	Cookies.set('{', 'v');
-	assert.strictEqual(Cookies.get('{'), 'v', 'should handle the opening curly brackets character');
-	assert.strictEqual(document.cookie, '%7B=v', 'opening curly brackets is not allowed, need to encode');
+	using(assert)
+	.setCookie('{', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the opening curly brackets character');
+		assert.strictEqual(plainValue, '%7B=v', 'opening curly brackets is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "}"', function (assert) {
 	assert.expect(2);
-	Cookies.set('}', 'v');
-	assert.strictEqual(Cookies.get('}'), 'v', 'should handle the closing curly brackets character');
-	assert.strictEqual(document.cookie, '%7D=v', 'closing curly brackets is not allowed, need to encode');
+	using(assert)
+	.setCookie('}', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the closing curly brackets character');
+		assert.strictEqual(plainValue, '%7D=v', 'closing curly brackets is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "\\t"', function (assert) {
 	assert.expect(2);
-	Cookies.set('	', 'v');
-	assert.strictEqual(Cookies.get('	'), 'v', 'should handle the horizontal tab character');
-	assert.strictEqual(document.cookie, '%09=v', 'horizontal tab is not allowed, need to encode');
+	using(assert)
+	.setCookie('	', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the horizontal tab character');
+		assert.strictEqual(plainValue, '%09=v', 'horizontal tab is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name " "', function (assert) {
 	assert.expect(2);
-	Cookies.set(' ', 'v');
-	assert.strictEqual(Cookies.get(' '), 'v', 'should handle the whitespace character');
-	assert.strictEqual(document.cookie, '%20=v', 'whitespace is not allowed, need to encode');
+	using(assert)
+	.setCookie(' ', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the whitespace character');
+		assert.strictEqual(plainValue, '%20=v', 'whitespace is not allowed, need to encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-name "#"', function (assert) {
 	assert.expect(2);
-	Cookies.set('#', 'v');
-	assert.strictEqual(Cookies.get('#'), 'v', 'should handle the sharp character');
-	assert.strictEqual(document.cookie, '#=v', 'sharp is allowed, should not encode');
+	using(assert)
+	.setCookie('#', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the sharp character');
+		assert.strictEqual(plainValue, '#=v', 'sharp is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-name "$"', function (assert) {
 	assert.expect(2);
-	Cookies.set('$', 'v');
-	assert.strictEqual(Cookies.get('$'), 'v', 'should handle the dollar sign character');
-	assert.strictEqual(document.cookie, '$=v', 'dollar sign is allowed, should not encode');
+	using(assert)
+	.setCookie('$', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the dollar sign character');
+		assert.strictEqual(plainValue, '$=v', 'dollar sign is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in cookie-name "%"', function (assert) {
 	assert.expect(2);
-	Cookies.set('%', 'v');
-	assert.strictEqual(Cookies.get('%'), 'v', 'should handle the percent character');
-	assert.strictEqual(document.cookie, '%25=v', 'percent is allowed, but need to be escaped');
+	using(assert)
+	.setCookie('%', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the percent character');
+		assert.strictEqual(plainValue, '%25=v', 'percent is allowed, but need to be escaped');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-name "&"', function (assert) {
 	assert.expect(2);
-	Cookies.set('&', 'v');
-	assert.strictEqual(Cookies.get('&'), 'v', 'should handle the ampersand character');
-	assert.strictEqual(document.cookie, '&=v', 'ampersand is allowed, should not encode');
+	using(assert)
+	.setCookie('&', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the ampersand character');
+		assert.strictEqual(plainValue, '&=v', 'ampersand is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-name "+"', function (assert) {
 	assert.expect(2);
-	Cookies.set('+', 'v');
-	assert.strictEqual(Cookies.get('+'), 'v', 'should handle the plus character');
-	assert.strictEqual(document.cookie, '+=v', 'plus is allowed, should not encode');
+	using(assert)
+	.setCookie('+', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the plus character');
+		assert.strictEqual(plainValue, '+=v', 'plus is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-name "^"', function (assert) {
 	assert.expect(2);
-	Cookies.set('^', 'v');
-	assert.strictEqual(Cookies.get('^'), 'v', 'should handle the caret character');
-	assert.strictEqual(document.cookie, '^=v', 'caret is allowed, should not encode');
+	using(assert)
+	.setCookie('^', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the caret character');
+		assert.strictEqual(plainValue, '^=v', 'caret is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-name "`"', function (assert) {
 	assert.expect(2);
-	Cookies.set('`', 'v');
-	assert.strictEqual(Cookies.get('`'), 'v', 'should handle the grave accent character');
-	assert.strictEqual(document.cookie, '`=v', 'grave accent is allowed, should not encode');
+	using(assert)
+	.setCookie('`', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the grave accent character');
+		assert.strictEqual(plainValue, '`=v', 'grave accent is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - character allowed in the cookie-name "|"', function (assert) {
 	assert.expect(2);
-	Cookies.set('|', 'v');
-	assert.strictEqual(Cookies.get('|'), 'v', 'should handle the pipe character');
-	assert.strictEqual(document.cookie, '|=v', 'pipe is allowed, should not encode');
+	using(assert)
+	.setCookie('|', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the pipe character');
+		assert.strictEqual(plainValue, '|=v', 'pipe is allowed, should not encode');
+	});
 });
 
 QUnit.test('RFC 6265 - characters allowed in the cookie-name should globally not be encoded', function (assert) {
 	assert.expect(1);
-	Cookies.set('||', 'v');
-	assert.strictEqual(document.cookie, '||=v', 'should not encode all character occurrences');
+	using(assert)
+	.setCookie('||', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(plainValue, '||=v', 'should not encode all character occurrences');
+	});
 });
 
 QUnit.test('cookie-name - 2 bytes characters', function (assert) {
 	assert.expect(2);
-	Cookies.set('ã', 'v');
-	assert.strictEqual(Cookies.get('ã'), 'v', 'should handle the ã character');
-	assert.strictEqual(document.cookie, '%C3%A3=v', 'should encode the ã character');
-	Cookies.remove('ã');
+	using(assert)
+	.setCookie('ã', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the ã character');
+		assert.strictEqual(plainValue, '%C3%A3=v', 'should encode the ã character');
+	});
 });
 
 QUnit.test('cookie-name - 3 bytes characters', function (assert) {
 	assert.expect(2);
-	Cookies.set('₯', 'v');
-	assert.strictEqual(Cookies.get('₯'), 'v', 'should handle the ₯ character');
-	assert.strictEqual(document.cookie, '%E2%82%AF=v', 'should encode the ₯ character');
-	Cookies.remove('₯');
+	using(assert)
+	.setCookie('₯', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should handle the ₯ character');
+		assert.strictEqual(plainValue, '%E2%82%AF=v', 'should encode the ₯ character');
+	});
 });
 
 QUnit.test('cookie-name - 4 bytes characters', function (assert) {
 	assert.expect(2);
-	Cookies.set('𩸽', 'v');
-	assert.strictEqual(Cookies.get('𩸽'), 'v', 'should_handle the 𩸽 character');
-	assert.strictEqual(document.cookie, '%F0%A9%B8%BD=v', 'should encode the 𩸽 character');
-	Cookies.remove('𩸽');
+	using(assert)
+	.setCookie('𩸽', 'v')
+	.then(function (decodedValue, plainValue) {
+		assert.strictEqual(decodedValue, 'v', 'should_handle the 𩸽 character');
+		assert.strictEqual(plainValue, '%F0%A9%B8%BD=v', 'should encode the 𩸽 character');
+	});
 });

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1,6 +1,6 @@
 /*global lifecycle: true*/
 
-QUnit.module('cookie-value encoding', lifecycle);
+QUnit.module('cookie-value', lifecycle);
 
 QUnit.test('cookie-value with double quotes', function (assert) {
 	assert.expect(1);
@@ -216,7 +216,7 @@ QUnit.test('cookie-value - 4 bytes character (𩸽)', function (assert) {
 	assert.strictEqual(document.cookie, 'c=%F0%A9%B8%BD', 'should encode the 𩸽 character');
 });
 
-QUnit.module('cookie-name encoding', lifecycle);
+QUnit.module('cookie-name', lifecycle);
 
 QUnit.test('RFC 6265 - character not allowed in the cookie-name "("', function (assert) {
 	assert.expect(2);

--- a/test/tests.js
+++ b/test/tests.js
@@ -48,14 +48,6 @@ QUnit.test('malformed cookie value in IE', function (assert) {
 	var done = assert.async();
 	// Sandbox in an iframe so that we can poke around with document.cookie.
 	var iframe = document.createElement('iframe');
-	var addEvent = function (element, eventName, fn) {
-		var method = 'addEventListener';
-		if (element.attachEvent) {
-			eventName = 'on' + eventName;
-			method = 'attachEvent';
-		}
-		element[ method ](eventName, fn);
-	};
 	iframe.src = 'malformed_cookie.html';
 	addEvent(iframe, 'load', function () {
 		if (iframe.contentWindow.ok) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -90,15 +90,17 @@
 							if ( !content ) {
 								ok(false, [
 									'"' + requestURL + '"',
-									'should return an object literal in the content body',
-									'with name and value keys'
+									'content should not be empty'
 								].join(' '));
 								done();
 								return;
 							}
-							var result = JSON.parse(content);
-							callback(result.value, iframeDocument.cookie);
-							done();
+							try {
+								var result = JSON.parse(content);
+								callback(result.value, iframeDocument.cookie);
+							} finally {
+								done();
+							}
 						});
 						iframe.src = requestURL;
 					}

--- a/test/utils.js
+++ b/test/utils.js
@@ -78,7 +78,7 @@
 					} else {
 						var requestURL = [
 							serverURL,
-							'/encoding?',
+							'encoding?',
 							'name=' + encodeURIComponent(name),
 							'&value=' + encodeURIComponent(value)
 						].join('');

--- a/test/utils.js
+++ b/test/utils.js
@@ -76,11 +76,17 @@
 					if (!serverURL) {
 						callback(Cookies.get(name), document.cookie);
 					} else {
-						var requestURL = serverURL + '/encoding/' + name;
+						var requestURL = [
+							serverURL,
+							'/encoding?',
+							'name=' + encodeURIComponent(name),
+							'&value=' + encodeURIComponent(value)
+						].join('');
 						var done = assert.async();
 						addEvent(iframe, 'load', function () {
 							var iframeDocument = iframe.contentWindow.document;
-							var content = iframeDocument.innerHTML;
+							var root = iframeDocument.documentElement;
+							var content = root.textContent;
 							if ( !content ) {
 								ok(false, [
 									'"' + requestURL + '"',
@@ -91,7 +97,7 @@
 								return;
 							}
 							var result = JSON.parse(content);
-							callback(result[name], iframeDocument.cookie);
+							callback(result.value, iframeDocument.cookie);
 							done();
 						});
 						iframe.src = requestURL;

--- a/test/utils.js
+++ b/test/utils.js
@@ -74,22 +74,24 @@
 					var serverURL = getQuery('integration_baseurl');
 					Cookies.set(name, value);
 					if (!serverURL) {
-						callback(Cookies.get(name));
+						callback(Cookies.get(name), document.cookie);
 					} else {
 						var requestURL = serverURL + '/encoding/' + name;
 						var done = assert.async();
 						addEvent(iframe, 'load', function () {
-							var content = iframe.contentWindow.document.innerHTML;
+							var iframeDocument = iframe.contentWindow.document;
+							var content = iframeDocument.innerHTML;
 							if ( !content ) {
 								ok(false, [
 									'"' + requestURL + '"',
 									'should return an object literal in the content body',
 									'with name and value keys'
 								].join(' '));
+								done();
 								return;
 							}
 							var result = JSON.parse(content);
-							callback(result[name]);
+							callback(result[name], iframeDocument.cookie);
 							done();
 						});
 						iframe.src = requestURL;


### PR DESCRIPTION
This basically creates a hook to make it possible to run the `js-cookie` encoding tests using the data from a server-side cookie handling implementation.

If the encoding tests are runned through `/encoding.html?integration_baseurl=`, then the `js-cookie` encoding tests will send the cookies through an iframe and read the processed return from the server.

**Why?**

1. It enforces the default encoding mechanism from server-side ports to be consistent with js-cookie. Due to the lack of standard of how to encode an invalid cookie character, If a cookie created in the server is read in the client, then it have to be "adapted" in the client using converters. By integrating a server-side solution against `js-cookie` encoding tests, the consistency is ensured.

2. The server-side port don't have to create all encoding tests again for it's language, it leverages the tests that are already written in JavaScript. There's no need to [duplicate the code](http://en.wikipedia.org/wiki/Don%27t_repeat_yourself).

3. It provides a hook for us to create server-side ports or plugins of the js-cookie API for other languages/frameworks