### PR TITLE
Document the CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ A simple, lightweight JavaScript API for handling cookies
 Include the script (unless you are packaging scripts somehow else):
 
 ```html
-<script src="/path/to/js.cookie.js"></script>
+<script src="//cdnjs.cloudflare.com/ajax/libs/js-cookie/2.0.0-beta.1/js.cookie.min.js"></script>
 ```
 
 **Do not include the script directly from GitHub (http://raw.github.com/...).** The file is being served as text/plain and as such being blocked


### PR DESCRIPTION
@carhartl 
What you think about documenting the CDN in the "installation" section?

Pros:
* People might rely less on `src/js.cookie.js` file on master that may be unstable
* Encourages the use of CDN for general sites instead of downloading the unminified source
* It provides a documented way to download the minified version instead of having to upload on each release (there were several requests in the past to provide the minified version)

Cons:
* It's hard to maintain the link consistently on each tagged release. cdnjs picks a new version **after** a tag is pushed[1]. If we rely in that, the tag view will retain the link of the previous version instead of the new one.

*[1]: I didn't tested if this is working, it is just how cdnjs documents the ["autoupdate" feature](https://github.com/cdnjs/cdnjs/tree/31eee715a9ffa7a6e739da45b7083c0b0dcbc266#enabling-gitrecommended-or-npm-auto-update) they rely upon and how I [set up](https://github.com/cdnjs/cdnjs/blob/31eee715a9ffa7a6e739da45b7083c0b0dcbc266/ajax/libs/js-cookie/package.json#L16-L23) js-cookie on cdnjs.*