### PR TITLE
Testing if the build status matrix shows only for the master branch

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -30,8 +30,8 @@ module.exports = function (grunt) {
 				options: {
 					urls: [
 						'http://127.0.0.1:9998/',
-						'http://127.0.0.1:9998/amd.html',
-						'http://127.0.0.1:9998/encoding.html?integration_baseurl=http://127.0.0.1:9998/'
+						'http://127.0.0.1:9998/amd.html'
+						// 'http://127.0.0.1:9998/encoding.html?integration_baseurl=http://127.0.0.1:9998/'
 					]
 				}
 			},

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -56,7 +56,7 @@
 				} catch (e) {}
 
 				value = encodeURIComponent(String(value));
-				value = value.replace(/%(23|24|26|2B|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				value = value.replace(/%(2C|23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
 
 				key = encodeURIComponent(String(key));
 				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -56,7 +56,7 @@
 				} catch (e) {}
 
 				value = encodeURIComponent(String(value));
-				value = value.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+				value = value.replace(/%(23|24|26|2B|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
 
 				key = encodeURIComponent(String(key));
 				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);


### PR DESCRIPTION
This PR is just to test if the build status matrix is really for the "master branch" as specified in the README. My assumption is that "https://saucelabs.com/u/js-cookie" will trigger despite the branch it was created, as long as it is created by an authorized user (see #13).

By not encoding the comma character as the cookie value in this test branch, it should work in chrome, but fail to set the value in Safari. If the image in the README shows the failure, then it means it does not consider only the "master branch" and the message should be removed.

**EDIT:**

It wasn't necessary to wait for any failure. It indeed changes for any authorized PR, not just commits in the master branch.

![image](https://cloud.githubusercontent.com/assets/835857/8149920/799abc16-12ac-11e5-8dc5-9103c3847edc.png)

I precipitated myself on commit https://github.com/js-cookie/js-cookie/commit/04b6544f90c219ca5100889b9a544f2420026839.