### PR TITLE
Fixed: some falsy secure option values modified cookie path

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -67,7 +67,7 @@
 					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
 					attributes.path    && '; path=' + attributes.path,
 					attributes.domain  && '; domain=' + attributes.domain,
-					attributes.secure  && '; secure'
+					(attributes.secure  && '; secure') || '' // use '' for falsy values, because [NaN, false, 0].join('') === 'NaNfalse0;
 				].join(''));
 			}
 

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -67,7 +67,7 @@
 					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
 					attributes.path    && '; path=' + attributes.path,
 					attributes.domain  && '; domain=' + attributes.domain,
-					(attributes.secure  && '; secure') || '' // use '' for falsy values, because [NaN, false, 0].join('') === 'NaNfalse0;
+					(attributes.secure  && '; secure') || ''
 				].join(''));
 			}
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -174,6 +174,33 @@ QUnit.test('API for changing defaults', function (assert) {
 	assert.ok(Cookies.set('c', 'v').match(/path=\//), 'should roll back to the default path');
 });
 
+QUnit.test('falsy secure value', function (assert) {
+	var falsyValues = [
+		false,
+		null,
+		undefined,
+		0,
+		NaN,
+		''
+	];
+
+	assert.expect(falsyValues.length);
+	var expected = 'c=v; path=/';
+
+	falsyValues.forEach(function (secureFalsyValue) {
+		var falsyName;
+
+		if ('' === secureFalsyValue) {
+			falsyName = 'Zero length string';
+		} else {
+			falsyName = secureFalsyValue + '';
+		}
+
+		var actual = Cookies.set('c', 'v', {secure: secureFalsyValue});
+		assert.strictEqual(actual, expected, falsyName + ' should not break the cookie');
+	});
+});
+
 QUnit.module('remove', lifecycle);
 
 QUnit.test('deletion', function (assert) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -174,31 +174,11 @@ QUnit.test('API for changing defaults', function (assert) {
 	assert.ok(Cookies.set('c', 'v').match(/path=\//), 'should roll back to the default path');
 });
 
-QUnit.test('falsy secure value', function (assert) {
-	var falsyValues = [
-		false,
-		null,
-		undefined,
-		0,
-		NaN,
-		''
-	];
-
-	assert.expect(falsyValues.length);
+QUnit.test('false secure value', function (assert) {
+	assert.expect(1);
 	var expected = 'c=v; path=/';
-
-	falsyValues.forEach(function (secureFalsyValue) {
-		var falsyName;
-
-		if ('' === secureFalsyValue) {
-			falsyName = 'Zero length string';
-		} else {
-			falsyName = secureFalsyValue + '';
-		}
-
-		var actual = Cookies.set('c', 'v', {secure: secureFalsyValue});
-		assert.strictEqual(actual, expected, falsyName + ' should not break the cookie');
-	});
+	var actual = Cookies.set('c', 'v', {secure: false});
+	assert.strictEqual(actual, expected, 'false should not modify path in cookie string');
 });
 
 QUnit.module('remove', lifecycle);


### PR DESCRIPTION
Hi,

Found and fixed issue when some falsy values modified cookie path in resulting cookie string due to implicit conversion to string inside Array.join() method.

```javascript
Cookies.set('c', 'v', {secure: false}) === "c=v; path=/false";
Cookies.set('c', 'v', {secure: NaN}) === "c=v; path=/NaN";
Cookies.set('c', 'v', {secure: 0}) === "c=v; path=/0";
```

Expected value for all tests is `"c=v; path=/"`