### PR TITLE
Test the behavior for `undefined` value in custom attributes

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -182,6 +182,22 @@ QUnit.test('false secure value', function (assert) {
 	assert.strictEqual(actual, expected, 'false should not modify path in cookie string');
 });
 
+QUnit.test('undefined attribute value', function (assert) {
+	assert.expect(4);
+	assert.strictEqual(Cookies.set('c', 'v', {
+		expires: undefined
+	}), 'c=v; path=/', 'should not write undefined expires attribute');
+	assert.strictEqual(Cookies.set('c', 'v', {
+		path: undefined
+	}), 'c=v', 'should not write undefined path attribute');
+	assert.strictEqual(Cookies.set('c', 'v', {
+		domain: undefined
+	}), 'c=v; path=/', 'should not write undefined domain attribute');
+	assert.strictEqual(Cookies.set('c', 'v', {
+		secure: undefined
+	}), 'c=v; path=/', 'should not write undefined secure attribute');
+});
+
 QUnit.module('remove', lifecycle);
 
 QUnit.test('deletion', function (assert) {


### PR DESCRIPTION
A few months ago @Krinkle [identified](https://github.com/carhartl/jquery-cookie/issues/308) an API problem when passing `undefined` to the cookie value. Basically in that situation, the return of a function that is supposed to generate a cookie value should not be interpreted as a getter.

Now we have a similar situation with the cookie attributes. The documentation doesn't say that `undefined` is a valid input for a cookie attribute, so the intent of the code just assumes the value will be truthy and uses `&&` to check for it. The only actual benefit of using logical `&&` operator was to reduce a few bytes gzipped when they were removed in bulk  [here](https://github.com/js-cookie/js-cookie/commit/78a3b44b82c997b9b682af1b34b72a664f8cc563).

**Fortunately**, `[undefined].join('')` returns `""` in the [operation to persist the cookie](https://github.com/js-cookie/js-cookie/blob/76932e33d9b4a50789c2edb0a1aa9657fde9b829/src/js.cookie.js#L71), so it doesn't write `c=v; path=/undefined` for `domain: undefined` like what [happened to the `expires: false` attribute](https://github.com/js-cookie/js-cookie/pull/54).

**Unfortunately** that is not tested.

* This PR test the behavior to ensure that if the code changes, the behavior will always stay the same.
* In other hand I don't know if the test is entirely necessary, because it also define a noop behavior for the `undefined` value, which might not be wise since it will become implicitly supported and cannot be changed in any future minor version bump.

Example:

```javascript
var domain = getDomain(); // returns undefined
Cookies.set('name', 'value', {
    domain: domain
    // domain: undefined
});
```

Is it worth testing this behavior?