### PR TITLE
Should not prevent a cookie to be retrieved if there is another malformed one

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -93,22 +93,24 @@
 					cookie = cookie.slice(1, -1);
 				}
 
-				cookie = converter && converter(cookie, name) || cookie.replace(rdecode, decodeURIComponent);
+				try {
+					cookie = converter && converter(cookie, name) || cookie.replace(rdecode, decodeURIComponent);
 
-				if (this.json) {
-					try {
-						cookie = JSON.parse(cookie);
-					} catch (e) {}
-				}
+					if (this.json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
 
-				if (key === name) {
-					result = cookie;
-					break;
-				}
+					if (key === name) {
+						result = cookie;
+						break;
+					}
 
-				if (!key) {
-					result[name] = cookie;
-				}
+					if (!key) {
+						result[name] = cookie;
+					}
+				} catch (e) {}
 			}
 
 			return result;

--- a/test/tests.js
+++ b/test/tests.js
@@ -79,6 +79,15 @@ QUnit.test('RFC 6265 - reading cookie-octet enclosed in DQUOTE', function (asser
 	assert.strictEqual(Cookies.get('c'), 'v', 'should simply ignore quoted strings');
 });
 
+QUnit.test('Call to read cookie when there is another unrelated cookie with malformed encoding in the value', function (assert) {
+	assert.expect(2);
+	document.cookie = 'invalid=%A1';
+	document.cookie = 'c=v';
+	assert.strictEqual(Cookies.get('c'), 'v', 'should not throw a URI malformed exception when retrieving a single cookie');
+	assert.deepEqual(Cookies.get(), { c: 'v' }, 'should not throw a URI malformed exception when retrieving all cookies');
+	Cookies.withConverter(unescape).remove('invalid');
+});
+
 QUnit.module('write', lifecycle);
 
 QUnit.test('String primitive', function (assert) {


### PR DESCRIPTION
If there is a malformed cookie that cannot be decoded using the default decoding mechanism, the malformed exception should be ignored and fail to read that single cookie. It should not prevent an unrelated cookie to be retrieved.

This seems to be related to https://github.com/carhartl/jquery-cookie/commit/81dd6a1596bdcd8e6c4008fcfc6d42825a7c4a2f. What happened is that the original code tested for a single percent character, while in this case the encoding is in a valid percent-encoding format that fails to be decoded by `decodeURIComponent` spec.

Brought up thanks to @TeamIguana, in his [comment](https://github.com/js-cookie/js-cookie/pull/60#issuecomment-119565763).

It might be related to the following report: https://github.com/js-cookie/js-cookie/issues/55