### PR TITLE
Fix the documentation, Cookies.remove() do not use use the converters.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Cookies.remove('name', { secure: true });
 ## Converter
 
 Create a new instance of the api that overrides the default decoding implementation.  
-All methods that rely in a proper decoding to work, such as `Cookies.remove()` and `Cookies.get()`, will run the converter first for each cookie.  
+All get methods that rely in a proper decoding to work, such as `Cookies.get()` and `Cookies.get('name')`, will run the converter first for each cookie.  
 The returning String will be used as the cookie value.
 
 Example from reading one of the cookies that can only be decoded using the `escape` function:


### PR DESCRIPTION
The converters are currently being used to adapt third party cookies for
reading only, the "remove()" method do not retrieve anything so it
doesn't make sense using the current converter.