### PR TITLE
The JSON-js polyfill note in the README should not include IE8

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Cookies.getJSON('name'); // => { foo: 'bar' }
 Cookies.getJSON(); // => { name: { foo: 'bar' } }
 ```
 
-*Note: To support IE6-8 you need to include the JSON-js polyfill: https://github.com/douglascrockford/JSON-js*
+*Note: To support IE6-7 you need to include the JSON-js polyfill: https://github.com/douglascrockford/JSON-js*
 
 ## Encoding
 


### PR DESCRIPTION
IE8 supports JSON