### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple, lightweight JavaScript API for handling cookies
 * No dependency
 * [Unobtrusive](#json) JSON support
 * Supports AMD/CommonJS
-* [RFC 6265](http://www.rfc-editor.org/rfc/rfc6265.txt) compliant
+* [RFC 6265](https://tools.ietf.org/html/rfc6265) compliant
 * Enable [custom decoding](#converter)
 * **~800 bytes** gzipped!
 


### PR DESCRIPTION
Changed RFC6265 link to actual [IETF](https://tools.ietf.org/html/) website. The IETF is the organization that manages RFCs.