### PR TITLE
Automatic release process

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,6 +232,7 @@ module.exports = function (grunt) {
 				// in the README
 				npm: false,
 				afterBump: ['replace:source'],
+				afterRelease: ['replace:readme-link'],
 				github: {
 					repo: 'js-cookie/js-cookie',
 					accessTokenVar: 'GH_JS_COOKIE_ACCESS_TOKEN'
@@ -245,6 +246,14 @@ module.exports = function (grunt) {
 				replacements: [{
 					from: /\* JavaScript Cookie v[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}/,
 					to: '* JavaScript Cookie v<%= pkg.version %>'
+				}]
+			},
+			'readme-link': {
+				src: ['README.md'],
+				overwrite: true,
+				replacements: [{
+					from: /\[View documentation for the latest release \([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}\).\]\(https:\/\/github\.com\/js-cookie\/js-cookie\/tree\/v[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}#readme\)/,
+					to: '[View documentation for the latest release (<%= pkg.version %>).](https://github.com/js-cookie/js-cookie/tree/v<%= pkg.version %>#readme)'
 				}]
 			}
 		}

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -231,10 +231,21 @@ module.exports = function (grunt) {
 				// Release on npm should be done after linking the latest release documentation
 				// in the README
 				npm: false,
+				afterBump: ['replace:source'],
 				github: {
 					repo: 'js-cookie/js-cookie',
 					accessTokenVar: 'GH_JS_COOKIE_ACCESS_TOKEN'
 				}
+			}
+		},
+		replace: {
+			source: {
+				src: ['src/js.cookie.js'],
+				overwrite: true,
+				replacements: [{
+					from: /\* JavaScript Cookie v[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}/,
+					to: '* JavaScript Cookie v<%= pkg.version %>'
+				}]
 			}
 		}
 	});

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -223,6 +223,19 @@ module.exports = function (grunt) {
 					}())
 				}
 			}
+		},
+		release: {
+			options: {
+				commitMessage: 'Release version <%= version %>',
+				tagName: 'v<%= version %>',
+				// Release on npm should be done after linking the latest release documentation
+				// in the README
+				npm: false,
+				github: {
+					repo: 'js-cookie/js-cookie',
+					accessTokenVar: 'GH_JS_COOKIE_ACCESS_TOKEN'
+				}
+			}
 		}
 	});
 

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -231,8 +231,18 @@ module.exports = function (grunt) {
 				// Release on npm should be done after linking the latest release documentation
 				// in the README
 				npm: false,
+				// The push is done via grunt-shell
+				push: false,
+				// As from the date of this comment, this is implicit, but undocumented
+				// remote: 'origin',
 				afterBump: ['replace:source'],
-				afterRelease: ['replace:readme-link', 'shell:commit-post-release'],
+				afterRelease: [
+					'replace:readme-link',
+					'shell:stage-post-release-message',
+					'shell:commit-post-release-message',
+					'prompt:choose-refspec-to-push-post-release-message',
+					'shell:push-post-release-message'
+				],
 				github: {
 					repo: 'js-cookie/js-cookie',
 					accessTokenVar: 'GH_JS_COOKIE_ACCESS_TOKEN'
@@ -258,8 +268,30 @@ module.exports = function (grunt) {
 			}
 		},
 		shell: {
-			'commit-post-release': {
+			'stage-post-release-message': {
+				command: 'git add README.md'
+			},
+			'commit-post-release-message': {
 				command: 'git commit -m "Prepare for the next development iteration"'
+			},
+			'push-post-release-message': {
+				command: function () {
+					var refspec = grunt.config('jscookie.release.push.refspec') || 'HEAD';
+					return 'git push origin ' + refspec;
+				}
+			}
+		},
+		prompt: {
+			'choose-refspec-to-push-post-release-message': {
+				options: {
+					questions: [{
+						config: 'jscookie.release.push.refspec',
+						type: 'list',
+						message: 'Push all changes to:',
+						choices: ['HEAD', 'master'],
+						default: 'master'
+					}]
+				}
 			}
 		}
 	});

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -310,6 +310,12 @@ module.exports = function (grunt) {
 
 	grunt.registerTask('saucelabs', ['connect:build-sauce', 'saucelabs-qunit']);
 	grunt.registerTask('test', ['jshint', 'jscs', 'connect:build-qunit', 'qunit', 'nodeunit']);
+	grunt.registerTask('ship', function (target) {
+		if (!target) {
+			grunt.fail.fatal('You need to provide a target, such as grunt ship:patch');
+		}
+		grunt.task.run('default', 'release:' + target);
+	});
 
 	grunt.registerTask('dev', ['test', 'uglify', 'compare_size']);
 	grunt.registerTask('ci', ['test', 'saucelabs']);

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -241,7 +241,8 @@ module.exports = function (grunt) {
 					'shell:stage-post-release-message',
 					'shell:commit-post-release-message',
 					'prompt:choose-refspec-to-push-post-release-message',
-					'shell:push-post-release-message'
+					'shell:push-post-release-message',
+					'npm-publish'
 				],
 				github: {
 					repo: 'js-cookie/js-cookie',
@@ -279,6 +280,9 @@ module.exports = function (grunt) {
 					var refspec = grunt.config('jscookie.release.push.refspec') || 'HEAD';
 					return 'git push origin ' + refspec;
 				}
+			},
+			'npm-publish': {
+				command: 'npm publish ./'
 			}
 		},
 		prompt: {

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -228,6 +228,7 @@ module.exports = function (grunt) {
 			options: {
 				commitMessage: 'Release version <%= version %>',
 				tagName: 'v<%= version %>',
+				tagMessage: 'v<%= version %>',
 				// Release on npm should be done after linking the latest release documentation
 				// in the README
 				npm: false,

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -232,7 +232,7 @@ module.exports = function (grunt) {
 				// in the README
 				npm: false,
 				afterBump: ['replace:source'],
-				afterRelease: ['replace:readme-link'],
+				afterRelease: ['replace:readme-link', 'shell:commit-post-release'],
 				github: {
 					repo: 'js-cookie/js-cookie',
 					accessTokenVar: 'GH_JS_COOKIE_ACCESS_TOKEN'
@@ -255,6 +255,11 @@ module.exports = function (grunt) {
 					from: /\[View documentation for the latest release \([0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}\).\]\(https:\/\/github\.com\/js-cookie\/js-cookie\/tree\/v[0-9]{1,2}.[0-9]{1,2}.[0-9]{1,2}#readme\)/,
 					to: '[View documentation for the latest release (<%= pkg.version %>).](https://github.com/js-cookie/js-cookie/tree/v<%= pkg.version %>#readme)'
 				}]
+			}
+		},
+		shell: {
+			'commit-post-release': {
+				command: 'git commit -m "Prepare for the next development iteration"'
 			}
 		}
 	});

--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ A simple, lightweight JavaScript API for handling cookies
 * Enable [custom encoding/decoding](#converters)
 * **~800 bytes** gzipped!
 
+<!-- This string is replaced via regex when a new version is released -->
 **If you're viewing this at https://github.com/js-cookie/js-cookie, you're reading the documentation for the master branch.
 [View documentation for the latest release (2.1.0).](https://github.com/js-cookie/js-cookie/tree/v2.1.0#readme)**
 
@@ -263,7 +264,6 @@ Check out the [Contributing Guidelines](CONTRIBUTING.md)
 
 * Run `grunt release` command with `:minor`, `:patch` or `:major` flags
 * Upload the minified file into the github release ([geddski/grunt-release#47](https://github.com/geddski/grunt-release/issues/47))
-* Link the documentation of the latest release tag in the `README.md`
 * Commit with the message "Prepare for the next development iteration"
 * Release on npm
 

--- a/README.md
+++ b/README.md
@@ -261,7 +261,6 @@ Check out the [Contributing Guidelines](CONTRIBUTING.md)
 
 ## Manual release steps
 
-* Increment the version number in the `src/js.cookie.js` file
 * Run `grunt release` command with `:minor`, `:patch` or `:major` flags
 * Upload the minified file into the github release ([geddski/grunt-release#47](https://github.com/geddski/grunt-release/issues/47))
 * Link the documentation of the latest release tag in the `README.md`

--- a/README.md
+++ b/README.md
@@ -261,11 +261,9 @@ Check out the [Contributing Guidelines](CONTRIBUTING.md)
 
 ## Manual release steps
 
-* Increment the "version" attribute of `package.json`
 * Increment the version number in the `src/js.cookie.js` file
-* Commit with the message "Release version x.x.x"
-* Create version tag in git
-* Create a github release and upload the minified file
+* Run `grunt release` command with `:minor`, `:patch` or `:major` flags
+* Upload the minified file into the github release ([geddski/grunt-release#47](https://github.com/geddski/grunt-release/issues/47))
 * Link the documentation of the latest release tag in the `README.md`
 * Commit with the message "Prepare for the next development iteration"
 * Release on npm

--- a/README.md
+++ b/README.md
@@ -264,7 +264,6 @@ Check out the [Contributing Guidelines](CONTRIBUTING.md)
 
 * Run `grunt release` command with `:minor`, `:patch` or `:major` flags
 * Upload the minified file into the github release ([geddski/grunt-release#47](https://github.com/geddski/grunt-release/issues/47))
-* Commit with the message "Prepare for the next development iteration"
 * Release on npm
 
 ## Authors

--- a/README.md
+++ b/README.md
@@ -260,11 +260,10 @@ Check out the [Servers Docs](SERVER_SIDE.md)
 
 Check out the [Contributing Guidelines](CONTRIBUTING.md)
 
-## Manual release steps
+## Release steps
 
 * Run `grunt release` command with `:minor`, `:patch` or `:major` flags
 * Upload the minified file into the github release ([geddski/grunt-release#47](https://github.com/geddski/grunt-release/issues/47))
-* Release on npm
 
 ## Authors
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-uglify": "0.11.1",
     "grunt-contrib-watch": "0.6.1",
     "grunt-jscs": "2.8.0",
+    "grunt-release": "0.13.0",
     "grunt-saucelabs": "8.6.2",
     "gzip-js": "0.3.2",
     "qunitjs": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "grunt-jscs": "2.8.0",
     "grunt-release": "0.13.0",
     "grunt-saucelabs": "8.6.2",
+    "grunt-text-replace": "0.4.0",
     "gzip-js": "0.3.2",
     "qunitjs": "1.22.0",
     "requirejs": "2.1.22"

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "grunt-jscs": "2.8.0",
     "grunt-release": "0.13.0",
     "grunt-saucelabs": "8.6.2",
+    "grunt-shell": "1.1.2",
     "grunt-text-replace": "0.4.0",
     "gzip-js": "0.3.2",
     "qunitjs": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "grunt-contrib-uglify": "0.11.1",
     "grunt-contrib-watch": "0.6.1",
     "grunt-jscs": "2.8.0",
+    "grunt-prompt": "1.3.3",
     "grunt-release": "0.13.0",
     "grunt-saucelabs": "8.6.2",
     "grunt-shell": "1.1.2",


### PR DESCRIPTION
This is a long-running PR that starts the implementation of a release process in parts, in order to remove the manual release and to start fixing the issues described in #57.

- [x]  Automate the linking to the documentation of the latest release tag in the `README.md`
- [x] Replace the version number in the header of the `src/js.cookie.js` file without using variables to keep the number in the original file
- [x] Implement `grunt-release`(or similar) to remove most part of the manual work
- [x] ~~Automatically upload the minified file into the github release~~ (grunt-release [does not support it](https://github.com/js-cookie/js-cookie/pull/82#issuecomment-136156493))
- [x] Automate the commit with the message "Prepare for the next development iteration"
- [x] Automate the release on npm
- [x] Review the README release docs
- [x] Test manually each release command one by one
- [x] Run tests before release, should stop if there are failures
- [x] ~~Comment the `npm publish ./` command and test the whole release manually~~

**Update March 20, 2016:**

I have considered creating a task-agnostic decoupled node module for releases that is easily testable.

Making Grunt tasks testable will require so many effort that it turns out creating a new module will be much more efficient.

Also, considering the amount of requirements from #57, it makes no sense coupling everything to a lot of Grunt Tasks. We need to have better maleability to be able to implement custom routines for the release process.

**Update March 29, 2016:**

Repository is public, still in development: https://github.com/js-cookie/js-cookie-release