### PR TITLE
add files to bower ignore

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,5 +3,10 @@
   "main": [
     "src/js.cookie.js"
   ],
-  "ignore": []
+  "ignore": [
+    "travis.sh",
+    "test",
+    "Gruntfile.js",
+    "package.json"
+  ]
 }

--- a/bower.json
+++ b/bower.json
@@ -7,6 +7,11 @@
     "travis.sh",
     "test",
     "Gruntfile.js",
-    "package.json"
+    "package.json",
+    ".gitignore",
+    ".jshintignore",
+    ".jshintrc",
+    ".tm_properties",
+    ".travis.yml"
   ]
 }


### PR DESCRIPTION
this removes clutter when installing `js-cookie` as a bower component