### PR TITLE
Fix problem when minifying with Uglify2

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -66,7 +66,7 @@
 				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
 				key = key.replace(/[\(\)]/g, escape);
 
-				var cookieString = key, '=', value;
+				var cookieString = key + '=' + value;
 				if (attributes.expires) {
 					cookieString += '; expires=' + attributes.expires.toUTCString(); // use expires attribute, max-age is not supported by IE
 				}

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -66,13 +66,22 @@
 				key = key.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent);
 				key = key.replace(/[\(\)]/g, escape);
 
-				return (document.cookie = [
-					key, '=', value,
-					attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
-					attributes.path    && '; path=' + attributes.path,
-					attributes.domain  && '; domain=' + attributes.domain,
-					attributes.secure ? '; secure' : ''
-				].join(''));
+				var cookieString = key, '=', value;
+				if (attributes.expires) {
+					cookieString += '; expires=' + attributes.expires.toUTCString(); // use expires attribute, max-age is not supported by IE
+				}
+				if (attributes.path) {
+					cookieString += '; path=' + attributes.path;
+				}
+				if (attributes.domain) {
+					cookieString += '; domain=' + attributes.domain;
+				}
+				if (attributes.secure) {
+					cookieString += '; secure';
+				}
+
+				document.cookie = cookieString;
+				return cookieString;
 			}
 
 			// Read


### PR DESCRIPTION
Code did not work because basically `[1, undefined, 2].join('')` gets minified to `1 + undefined + 2` in Uglify2 with compress.evaluate option set to true.
Also make code better understandable :)

Tested with https://skalman.github.io/UglifyJS-online/:
```javascript
function a() {
  return (document.cookie = [
    key, '=', value,
    attributes.expires && '; expires=' + attributes.expires.toUTCString(), // use expires attribute, max-age is not supported by IE
    attributes.path    && '; path=' + attributes.path,
    attributes.domain  && '; domain=' + attributes.domain,
    attributes.secure ? '; secure' : ''
  ].join(''));
}
```
```javascript
function a(){return document.cookie=key+"="+value+(attributes.expires&&"; expires="+attributes.expires.toUTCString())+(attributes.path&&"; path="+attributes.path)+(attributes.domain&&"; domain="+attributes.domain)+(attributes.secure?"; secure":"")}
```