### PR TITLE
Do not throw errors if the methods are called in node

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,7 +37,7 @@ module.exports = function (grunt) {
 			},
 		},
 		nodeunit: {
-			all: 'test/commonjs.js'
+			all: 'test/node.js'
 		},
 		jshint: {
 			options: {

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -34,6 +34,9 @@
 	function init (converter) {
 		function api (key, value, attributes) {
 			var result;
+			if (typeof document === 'undefined') {
+				return;
+			}
 
 			// Write
 

--- a/test/node.js
+++ b/test/node.js
@@ -1,5 +1,5 @@
 /*jshint node:true */
-exports.commonjs = {
+exports.node = {
 	should_load_js_cookie: function (test) {
 		test.expect(1);
 		var Cookies = require('../src/js.cookie');

--- a/test/node.js
+++ b/test/node.js
@@ -5,5 +5,25 @@ exports.node = {
 		var Cookies = require('../src/js.cookie');
 		test.ok(!!Cookies.get, 'should load the Cookies API');
 		test.done();
+	},
+	should_not_throw_error_for_set_call_in_node: function (test) {
+		test.expect(0);
+		var Cookies = require('../src/js.cookie');
+		Cookies.set('anything');
+		Cookies.set('anything', { path: '' });
+		test.done();
+	},
+	should_not_throw_error_for_get_call_in_node: function (test) {
+		test.expect(0);
+		var Cookies = require('../src/js.cookie');
+		Cookies.get('anything');
+		test.done();
+	},
+	should_not_throw_error_for_remove_call_in_node: function (test) {
+		test.expect(0);
+		var Cookies = require('../src/js.cookie');
+		Cookies.remove('anything');
+		Cookies.remove('anything', { path: '' });
+		test.done();
 	}
 };


### PR DESCRIPTION
This is basically to make it possible to run an entire front-end codebase also in the back-end. We should not make assumptions about the environment the code is running, just check if the necessary dependencies exist (in this case a `document`).

This does not mean that the lib has a defined behavior when running in an environment different from the browser. The behavior of the lib in unkown environments, such as node, is undefined, we just ensure it doesn't throw errors.

**Code size after this change:**
<img width="564" alt="screenshot 2016-03-30 23 10 51" src="https://cloud.githubusercontent.com/assets/835857/14141747/ae4408a0-f6cc-11e5-9e7d-bb1e6e4a0599.png">
