### PR TITLE
Do not create cookie if using .set() incorrectly

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -125,7 +125,10 @@
 			return result;
 		}
 
-		api.get = api.set = api;
+		api.set = api;
+		api.get = function (key) {
+			return api(key);
+		};
 		api.getJSON = function () {
 			return api.apply({
 				json: true

--- a/test/tests.js
+++ b/test/tests.js
@@ -89,6 +89,13 @@ QUnit.test('Call to read cookie when there is another unrelated cookie with malf
 	Cookies.withConverter(unescape).remove('invalid');
 });
 
+// github.com/js-cookie/js-cookie/issues/145
+QUnit.test('Call to read cookie when passing an Object Literal as the second argument', function (assert) {
+	assert.expect(1);
+	Cookies.get('name', { path: '' });
+	assert.strictEqual(document.cookie, '', 'should not create a cookie');
+});
+
 QUnit.module('write', lifecycle);
 
 QUnit.test('String primitive', function (assert) {


### PR DESCRIPTION
If someone uses the undocumented `.set(String, Object Literal)` signature, there should be no side-effect of creating the cookie for a read operation.

<img width="539" alt="screenshot 2016-04-10 00 48 53" src="https://cloud.githubusercontent.com/assets/835857/14404320/04cb4742-feb6-11e5-8602-a23529976f42.png">
