### PR TITLE
Update grunt to version 1.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 language: node_js
 node_js:
-  - '0.10'
-before_script:
-  - npm install -g grunt-cli
+  - '5.1.1'
 # Only use grunt-ci for commits pushed to this repo. Fall back to regular test
 # for pull requests (as secure variables won't be exposed there).
 script:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Klaus Hartl",
   "license": "MIT",
   "devDependencies": {
-    "grunt": "0.4.5",
+    "grunt": "1.0.0",
     "grunt-compare-size": "0.4.0",
     "grunt-contrib-connect": "1.0.0",
     "grunt-contrib-jshint": "1.0.0",


### PR DESCRIPTION
As from [the changelog](http://gruntjs.com/blog/2016-04-04-grunt-1.0.0-released), now a grunt bin is created upon install.

Instead of fixing the `peerDependencies` in the offending packages as suggested by the changelod, I just updated the node version used in the CI, since the build doesn't fail for higher versions of node.