### PR TITLE
Attempt to fix Sauce Labs where the tunnel closes early.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: node_js
 node_js:
-  - '5.1.1'
+  - '0.10'
+before_script:
+  - npm install -g grunt-cli
 # Only use grunt-ci for commits pushed to this repo. Fall back to regular test
 # for pull requests (as secure variables won't be exposed there).
 script:

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
   "author": "Klaus Hartl",
   "license": "MIT",
   "devDependencies": {
-    "grunt": "1.0.0",
+    "grunt": "0.4.5",
     "grunt-compare-size": "0.4.0",
     "grunt-contrib-connect": "1.0.0",
     "grunt-contrib-jshint": "1.0.0",


### PR DESCRIPTION
This is the problem that is happening on CI (the tunnel closes early):

```shell
=> Starting Tunnel to Sauce Labs
=> Sauce Labs trying to open tunnel
>> => Sauce Labs Tunnel established
>> Connected to Saucelabs
 1 / 16 tests started
 2 / 16 tests started
 3 / 16 tests started
 4 / 16 tests started
=> Stopping Tunnel to Sauce Labs
 5 / 16 tests started
 6 / 16 tests started
>> 
>> Sauce Labs Tunnel disconnected
>> Error: POST https://saucelabs.com/rest/v1/js-cookie/js-tests failed.
>>     at /home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/src/utils.js:97:15
>>     at _rejected (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/node_modules/q/q.js:830:24)
>>     at /home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/node_modules/q/q.js:856:30
>>     at Promise.when (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/node_modules/q/q.js:1108:31)
>>     at Promise.promise.promiseDispatch (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/node_modules/q/q.js:774:41)
>>     at /home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/node_modules/q/q.js:590:44
>>     at runSingle (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/node_modules/q/q.js:123:13)
>>     at flush (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/node_modules/q/q.js:111:13)
>>     at process._tickCallback (node.js:458:13)
>>     Error: HTTP error (429)
>>         at /home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/src/utils.js:91:17
>>     From previous event:
>>         at Object.makeRequest (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/src/utils.js:86:8)
>>         at Job.start (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/src/Job.js:86:8)
>>         at getResult (/home/travis/build/js-cookie/js-cookie/node_modules/grunt-saucelabs/src/TestRunner.js:113:10)
Warning: Task "saucelabs-qunit:all" failed. Use --force to continue.
Aborted due to warnings.
The command "./travis.sh" exited with 3.
Done. Your build exited with 1.
```

**Attempt 1:**
<strike>I suspect this might be related to the Grunt upgrade, but wasn't spot early because Sauce only runs in commits or PRs created by [js-cookie members](https://github.com/orgs/js-cookie/people).</strike>

Even reverting Grunt it keeps failing.

[Inspecting the history](https://travis-ci.org/js-cookie/js-cookie/builds), it seems that it started failing between e9e61769c4e8 (pass) and dbce759 (fails):

<img width="1098" alt="screenshot 2016-04-16 19 53 02" src="https://cloud.githubusercontent.com/assets/835857/14580307/dc813114-040c-11e6-8724-aaaaba0a7c1a.png">

[Here are the changes between both commits](https://github.com/js-cookie/js-cookie/compare/e9e6176...dbce759) above, nothing touches any Sauce Labs dependency. We use fixed `package.json` dependency versions, so it is likely to be an upstream issue.

Trying to restart [the build 522 on Travis](https://travis-ci.org/js-cookie/js-cookie/builds/123090165) that was previously passing, so that we can be 100% certain that this problem is not in js-cookie...

Confirmed! [Build 522 fails](https://travis-ci.org/js-cookie/js-cookie/builds/123090165) just by restarting it, it probably happens to all build. The problem is probably with Sauce Labs, creating bug report...

Report sent as a maximum priority level, case ID is 38251.