### PR TITLE
Add gif file aligned on top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<p align="center">
+  <img src="https://cloud.githubusercontent.com/assets/835857/14581711/ba623018-0436-11e6-8fce-d2ccd4d379c9.gif">
+</p>
+
 # JavaScript Cookie [![Build Status](https://travis-ci.org/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.org/js-cookie/js-cookie) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie)
 
 A simple, lightweight JavaScript API for handling cookies


### PR DESCRIPTION
This adds a gif file on the top of the README so that anyone that wants to use the lib don't waste a single second reading how to use the basic of it. The standard interface is so simple that we can express how it works in a small gif like this.

See [here](https://github.com/js-cookie/js-cookie/tree/350bce64dd9cee734fcc2e0d57c8815bc739f90f#readme) for an example.