### PR TITLE
Correct notice on attributes in remove function

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Cookies.remove('name'); // fail!
 Cookies.remove('name', { path: '' }); // removed!
 ```
 
-*IMPORTANT! when deleting a cookie, you must pass the exact same path, domain and secure attributes that were used to set the cookie, unless you're relying on the [default attributes](#cookie-attributes).*
+*IMPORTANT! when deleting a cookie, you must pass the exact same path and domain attributes that was used to set the cookie, unless you're relying on the [default attributes](#cookie-attributes).*
 
 ## Namespace conflicts
 


### PR DESCRIPTION
The notice stated that path, domain and secure attributes needs to be the same
as when the cookie was created when removing a cookie, but in reality only the
path and domain attributes needs to be the same. This commit removes "secure"
from this notice.