### PR TITLE
Update QUnit to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "grunt-jscs": "3.0.0",
     "grunt-saucelabs": "8.6.2",
     "gzip-js": "0.3.2",
-    "qunitjs": "1.23.1",
+    "qunitjs": "2.0.0",
     "requirejs": "2.2.0"
   }
 }

--- a/test/amd.js
+++ b/test/amd.js
@@ -3,7 +3,7 @@ require(['qunit'], function (QUnit) {
 
 	QUnit.start();
 	QUnit.test('module loading', function (assert) {
-		QUnit.expect(1);
+		assert.expect(1);
 		var done = assert.async();
 		require(['/src/js.cookie.js'], function (Cookies) {
 			assert.ok(!!Cookies.get, 'should load the api');


### PR DESCRIPTION
For some reason the build on IE started failing in Sauce Labs after https://github.com/js-cookie/js-cookie/commit/337419f7366264c2c9bc34ec6f69d9fd434ceb35, need to investigate.

See https://travis-ci.org/js-cookie/js-cookie/builds/138708313#L1035-L1056