### PR TITLE
Remove QUnit.expect from amd test

### DIFF
--- a/test/amd.js
+++ b/test/amd.js
@@ -3,7 +3,7 @@ require(['qunit'], function (QUnit) {
 
 	QUnit.start();
 	QUnit.test('module loading', function (assert) {
-		QUnit.expect(1);
+		assert.expect(1);
 		var done = assert.async();
 		require(['/src/js.cookie.js'], function (Cookies) {
 			assert.ok(!!Cookies.get, 'should load the api');


### PR DESCRIPTION
QUnit v2 have [removed this API](http://qunitjs.com/upgrade-guide-2.x/#replace-expect-with-assert-expect). This prepares for when we decide to upgrade.