### PR TITLE
Register in AMD and UMD if both available

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -31,6 +31,7 @@ module.exports = function (grunt) {
 					urls: [
 						'http://127.0.0.1:9998/',
 						'http://127.0.0.1:9998/amd.html',
+						'http://127.0.0.1:9998/environment-with-amd-and-umd.html',
 						'http://127.0.0.1:9998/encoding.html?integration_baseurl=http://127.0.0.1:9998/'
 					]
 				}

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ A simple, lightweight JavaScript API for handling cookies
 * [RFC 6265](https://tools.ietf.org/html/rfc6265) compliant
 * Useful [Wiki](https://github.com/js-cookie/js-cookie/wiki)
 * Enable [custom encoding/decoding](#converters)
-* **~800 bytes** gzipped!
+* **~900 bytes** gzipped!
 
 **If you're viewing this at https://github.com/js-cookie/js-cookie, you're reading the documentation for the master branch.
 [View documentation for the latest release (2.1.2).](https://github.com/js-cookie/js-cookie/tree/v2.1.2#readme)**

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -6,11 +6,16 @@
  * Released under the MIT license
  */
 ;(function (factory) {
+	var registeredInModuleLoader = false;
 	if (typeof define === 'function' && define.amd) {
 		define(factory);
-	} else if (typeof exports === 'object') {
+		registeredInModuleLoader = true;
+	}
+	if (typeof exports === 'object') {
 		module.exports = factory();
-	} else {
+		registeredInModuleLoader = true;
+	}
+	if (!registeredInModuleLoader) {
 		var OldCookies = window.Cookies;
 		var api = window.Cookies = factory();
 		api.noConflict = function () {

--- a/test/environment-with-amd-and-umd.html
+++ b/test/environment-with-amd-and-umd.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8">
+		<title>JavaScript Cookie Test Suite - Environment with AMD and UMD</title>
+		<link href="../node_modules/qunitjs/qunit/qunit.css" rel="stylesheet">
+		<script src="amd-config.js"></script>
+		<script src="../node_modules/requirejs/require.js"></script>
+		<script src="environment-with-amd-and-umd.js"></script>
+	</head>
+	<body>
+		<div id="qunit"></div>
+		<div id="qunit-fixture"></div>
+	</body>
+</html>

--- a/test/environment-with-amd-and-umd.js
+++ b/test/environment-with-amd-and-umd.js
@@ -1,0 +1,28 @@
+require(['qunit'], function (QUnit) {
+	QUnit.start();
+
+	QUnit.module('Environment with AMD and UMD', {
+		beforeEach: function () {
+			window.exports = {};
+			window.module = {
+				exports: window.exports
+			};
+		},
+		afterEach: function () {
+			delete window.module;
+		}
+	});
+
+	QUnit.test('js-cookie need to register itself in AMD and UMD', function (assert) {
+		assert.expect(2);
+		var done = assert.async();
+		require(['/src/js.cookie.js'], function () {
+			var actual = typeof window.module.exports;
+			var expected = 'function';
+			assert.strictEqual(actual, expected, 'should register a function in module.exports');
+			assert.notOk(!!window.Cookies, 'should not register globally in AMD/UMD environments');
+			done();
+		});
+	});
+
+});


### PR DESCRIPTION
Related to https://github.com/js-cookie/js-cookie/issues/244.

Sadly, this adds +8 bytes gzipped, which breaks the feature of `~800 bytes gzipped` stated [on the README](https://github.com/js-cookie/js-cookie/tree/72d05c27ebfb99aa8b6ae8f1b46210e223e815b9#javascript-cookie--) (not we have `901 bytes`):

<img width="547" alt="screenshot 2016-08-22 13 12 03" src="https://cloud.githubusercontent.com/assets/835857/17862097/305d5e40-686a-11e6-90b3-f84917bbb8eb.png">

@cllns can you please review this?

Also, do you have any idea on how we can make it so that it doesn't add `8 bytes` gzipped in a way that we don't need to update the README? Even reasonably alternative solutions for this use case that don't require changing the library will help not increasing the code size.