### PR TITLE
Change README to point to the 'latest' tag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ A simple, lightweight JavaScript API for handling cookies
 * **~900 bytes** gzipped!
 
 **If you're viewing this at https://github.com/js-cookie/js-cookie, you're reading the documentation for the master branch.
-[View documentation for the latest release (2.1.2).](https://github.com/js-cookie/js-cookie/tree/v2.1.2#readme)**
+[View documentation for the latest release.](https://github.com/js-cookie/js-cookie/tree/latest#readme)**
 
 ## Build Status Matrix
 
@@ -28,7 +28,7 @@ A simple, lightweight JavaScript API for handling cookies
 
 ### Direct download
 
-Download the script [here](https://github.com/js-cookie/js-cookie/blob/v2.1.2/src/js.cookie.js) and include it (unless you are packaging scripts somehow else):
+Download the script [here](https://github.com/js-cookie/js-cookie/blob/latest/src/js.cookie.js) and include it (unless you are packaging scripts somehow else):
 
 ```html
 <script src="/path/to/js.cookie.js"></script>
@@ -281,8 +281,6 @@ Check out the [Contributing Guidelines](CONTRIBUTING.md)
 * Change the `latest` tag pointer to the latest commit
   * `git tag -fa latest`
   * `git push <remote> :refs/tags/latest`
-* Link the documentation of the latest release tag in the `README.md`
-* Link the download link to the latest release tag in the `README.md`
 * Commit with the message "Prepare for the next development iteration"
 * Release on npm
 


### PR DESCRIPTION
Related to https://github.com/js-cookie/js-cookie/issues/210. Partially applied in the release process through https://github.com/js-cookie/js-cookie/pull/255.