### PR TITLE
Fix the release steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,9 +279,9 @@ Check out the [Contributing Guidelines](CONTRIBUTING.md)
 * Create version tag in git
 * Create a github release and upload the minified file
 * Change the `latest` tag pointer to the latest commit
-  * `git tag -fa latest`
+  * `git tag -f latest`
   * `git push <remote> :refs/tags/latest`
-* Commit with the message "Prepare for the next development iteration"
+  * `git push origin master --tags`
 * Release on npm
 
 ## Authors


### PR DESCRIPTION
The release steps were wrong since https://github.com/js-cookie/js-cookie/pull/255, just figured it out when actually doing the release.

It's reasonable since I didn't actually had the opportunity to test the flow manually when creating #255.