### PR TITLE
Added SameSite to cookie via attributes

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -56,6 +56,13 @@
 					attributes.expires = expires;
 				}
 
+        if (attributes.samesite !== 'Strict' && attributes.samesite !== 'Lax') {
+          if (attributes.samesite === true)
+            attributes.samesite = 'Strict';
+          else
+            attributes.samesite = undefined;
+        }
+
 				try {
 					result = JSON.stringify(value);
 					if (/^[\{\[]/.test(result)) {
@@ -79,7 +86,8 @@
 					attributes.expires ? '; expires=' + attributes.expires.toUTCString() : '', // use expires attribute, max-age is not supported by IE
 					attributes.path ? '; path=' + attributes.path : '',
 					attributes.domain ? '; domain=' + attributes.domain : '',
-					attributes.secure ? '; secure' : ''
+					attributes.secure ? '; secure' : '',
+					attributes.samesite ? '; SameSite=' + attributes.samesite : ''
 				].join(''));
 			}
 

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -56,12 +56,14 @@
 					attributes.expires = expires;
 				}
 
-        if (attributes.samesite !== 'Strict' && attributes.samesite !== 'Lax') {
-          if (attributes.samesite === true)
-            attributes.samesite = 'Strict';
-          else
-            attributes.samesite = undefined;
-        }
+				if (attributes.samesite !== 'Strict' && attributes.samesite !== 'Lax') {
+					if (attributes.samesite === true) {
+						attributes.samesite = 'Strict';
+					}
+					else {
+						attributes.samesite = undefined;
+					}
+				}
 
 				try {
 					result = JSON.stringify(value);

--- a/test/tests.js
+++ b/test/tests.js
@@ -241,8 +241,22 @@ QUnit.test('false secure value', function (assert) {
 	assert.strictEqual(actual, expected, 'false should not modify path in cookie string');
 });
 
+QUnit.test('false samesite value', function (assert) {
+	assert.expect(1);
+	var expected = 'c=v; path=/';
+	var actual = Cookies.set('c', 'v', {samesite: 'false'});
+	assert.strictEqual(actual, expected, 'false should not modify path in cookie string');
+});
+
+QUnit.test('adopted samesite value', function (assert) {
+	assert.expect(1);
+	var expected = 'c=v; path=/; SameSite=Strict';
+	var actual = Cookies.set('c', 'v', {samesite: true});
+	assert.strictEqual(actual, expected, 'true should be changed to Strict');
+});
+
 QUnit.test('undefined attribute value', function (assert) {
-	assert.expect(4);
+	assert.expect(5);
 	assert.strictEqual(Cookies.set('c', 'v', {
 		expires: undefined
 	}), 'c=v; path=/', 'should not write undefined expires attribute');
@@ -255,6 +269,9 @@ QUnit.test('undefined attribute value', function (assert) {
 	assert.strictEqual(Cookies.set('c', 'v', {
 		secure: undefined
 	}), 'c=v; path=/', 'should not write undefined secure attribute');
+	assert.strictEqual(Cookies.set('c', 'v', {
+		samesite: undefined
+	}), 'c=v; path=/', 'should not write undefined samesite attribute');
 });
 
 QUnit.module('remove', lifecycle);


### PR DESCRIPTION
I added samesite as a new options attribute. It will either be Strict or Lax. The inputs could be true, 'Strict' or 'Lax'.
For this I also added QUnit tests.

I know this attribute is not in RFC 6265, but this is a minor change which results in a new feature.
We from [SlideWiki](//github.com/slidewiki) will heavily benefit from this one.
