### PR TITLE
Use strict mode, avoid octal syntax in tests.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -60,7 +60,7 @@ module.exports = function (grunt) {
 				requireSpaceBeforeObjectValues: true,
 				validateIndentation: '\t',
 				validateLineBreaks: 'LF',
-				validateQuoteMarks: true,
+				validateQuoteMarks: {mark: '\'', escape: false},
 				disallowSpacesInsideArrayBrackets: 'all',
 				disallowSpacesInsideParentheses: true,
 				disallowTrailingWhitespace: true

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -3,6 +3,7 @@
 	"qunit": true,
 
 	"-W053": true,
+	"-W097": true, // disable warning for 'Use the function form of "use strict".'
 
 	"extends": "../.jshintrc",
 	"globals": {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -3,7 +3,7 @@
 	"qunit": true,
 
 	"-W053": true,
-	"-W097": true, // disable warning for 'Use the function form of "use strict".'
+	"-W097": true,
 
 	"extends": "../.jshintrc",
 	"globals": {

--- a/test/.jshintrc
+++ b/test/.jshintrc
@@ -3,7 +3,7 @@
 	"qunit": true,
 
 	"-W053": true,
-	"-W097": true,
+	"-W097": true, // disable warning for 'Use the function form of "use strict".'
 
 	"extends": "../.jshintrc",
 	"globals": {

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 /*global lifecycle: true*/
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -404,7 +404,7 @@ QUnit.test('Object Constructor', function (assert) {
 
 QUnit.test('Use String(value) for unsupported objects that do not stringify into JSON', function (assert) {
 	assert.expect(2);
-	Cookies.set('date', new Date(2015, 04, 13, 0, 0, 0, 0));
+	Cookies.set('date', new Date(2015, 4, 13, 0, 0, 0, 0));
 	assert.strictEqual(Cookies.get('date').indexOf('"'), -1, 'should not quote the stringified Date object');
 	assert.strictEqual(Cookies.getJSON('date').indexOf('"'), -1, 'should not quote the stringified Date object');
 });

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,3 +1,5 @@
+"use strict";
+
 /*global lifecycle: true*/
 
 QUnit.module('read', lifecycle);


### PR DESCRIPTION
According to https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode , strict mode does not tolerate leading zeroes. This was not meant to be octal anyway, so thank God the number was not bigger than 7. When I run this through Babel, I get the SyntaxError. It is therefore not purely theoretical.