### PR TITLE
Minor usability improvement to the readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ Cookies.getJSON(); // => { name: { foo: 'bar' } }
 
 This project is [RFC 6265](http://tools.ietf.org/html/rfc6265#section-4.1.1) compliant. All special characters that are not allowed in the cookie-name or cookie-value are encoded with each one's UTF-8 Hex equivalent using [percent-encoding](http://en.wikipedia.org/wiki/Percent-encoding).  
 The only character in cookie-name or cookie-value that is allowed and still encoded is the percent `%` character, it is escaped in order to interpret percent input as literal.  
-Please note that the default encoding/decoding strategy is meant to be interoperable [only between cookies that are read/written by js-cookie](https://github.com/js-cookie/js-cookie/pull/200#discussion_r63270778). To override the default encoding/decoding strategy you need to use a [converter](#converter).
+Please note that the default encoding/decoding strategy is meant to be interoperable [only between cookies that are read/written by js-cookie](https://github.com/js-cookie/js-cookie/pull/200#discussion_r63270778). To override the default encoding/decoding strategy you need to use a [converter](#converters).
 
 ## Cookie Attributes
 

--- a/README.md
+++ b/README.md
@@ -225,7 +225,7 @@ Cookies.get('name'); // => 'value'
 Cookies.remove('name', { secure: true });
 ```
 
-## Converters <a name="converter"></a>
+## Converters
 
 ### Read
 


### PR DESCRIPTION
Added an anchor in the converters section heading for the link from the encodings section to point to (previously, the anchor tag/name attribute didn't exist so the link didn't do anything)