### PR TITLE
Avoid error if window is not defined

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -15,7 +15,7 @@
 		module.exports = factory();
 		registeredInModuleLoader = true;
 	}
-	if (!registeredInModuleLoader) {
+	if (!registeredInModuleLoader && window) {
 		var OldCookies = window.Cookies;
 		var api = window.Cookies = factory();
 		api.noConflict = function () {


### PR DESCRIPTION
When included in a react module that is rendered server-side, we need to check for `window` being defined or else the server side thing could crash.