### PR TITLE
Update to the latest Node.js LTS version.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - '5.1.1'
+  - '6'
 # Only use grunt-ci for commits pushed to this repo. Fall back to regular test
 # for pull requests (as secure variables won't be exposed there).
 script:


### PR DESCRIPTION
Node.js v5 is no longer supported.  See https://github.com/nodejs/LTS.