### PR TITLE
Made the remove() return the removed value

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -151,9 +151,13 @@
 		api.defaults = {};
 
 		api.remove = function (key, attributes) {
+			var value = api.get(key);
+
 			api(key, '', extend(attributes, {
 				expires: -1
 			}));
+
+			return value;
 		};
 
 		api.withConverter = init;

--- a/test/tests.js
+++ b/test/tests.js
@@ -297,10 +297,12 @@ QUnit.test('undefined attribute value', function (assert) {
 QUnit.module('remove', lifecycle);
 
 QUnit.test('deletion', function (assert) {
-	assert.expect(1);
-	Cookies.set('c', 'v');
-	Cookies.remove('c');
+	assert.expect(2);
+	var value = 'v';
+	Cookies.set('c', value);
+	var removedValue = Cookies.remove('c');
 	assert.strictEqual(document.cookie, '', 'should delete the cookie');
+	assert.strictEqual(removedValue, value, 'should return the deleted value');
 });
 
 QUnit.test('with attributes', function (assert) {


### PR DESCRIPTION
A minor improvement for convenience in the case where you want to get a cookie then immediately remove it.