### PR TITLE
Do not remove quotes for json

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -109,7 +109,7 @@
 				var parts = cookies[i].split('=');
 				var cookie = parts.slice(1).join('=');
 
-				if (cookie.charAt(0) === '"') {
+				if (!this.json && cookie.charAt(0) === '"') {
 					cookie = cookie.slice(1, -1);
 				}
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -460,8 +460,8 @@ QUnit.test('Cookies with escaped quotes in json', function (assert) {
 			return value;
 		}
 	}).set('c', '"{ \\"foo\\": \\"bar\\" }"');
-	assert.deepEqual(Cookies.getJSON('c'), '{ "foo": "bar" }', 'returns JSON parsed cookie');
-	assert.deepEqual(Cookies.get('c'), '{ \\"foo\\": \\"bar\\" }', 'returns unparsed cookie with enclosing quotes removed');
+	assert.strictEqual(Cookies.getJSON('c'), '{ "foo": "bar" }', 'returns JSON parsed cookie');
+	assert.strictEqual(Cookies.get('c'), '{ \\"foo\\": \\"bar\\" }', 'returns unparsed cookie with enclosing quotes removed');
 });
 
 QUnit.module('noConflict', lifecycle);

--- a/test/tests.js
+++ b/test/tests.js
@@ -461,7 +461,7 @@ QUnit.test('Cookies with escaped quotes in json', function (assert) {
 		}
 	}).set('c', '"{ \\"foo\\": \\"bar\\" }"');
 	assert.deepEqual(Cookies.getJSON('c'), '{ "foo": "bar" }', 'returns JSON parsed cookie');
-	assert.deepEqual(Cookies.get('c'), '{ \\"foo\\": \\"bar\\" }', 'returns unparsed cookie');
+	assert.deepEqual(Cookies.get('c'), '{ \\"foo\\": \\"bar\\" }', 'returns unparsed cookie with enclosing quotes removed');
 });
 
 QUnit.module('noConflict', lifecycle);

--- a/test/tests.js
+++ b/test/tests.js
@@ -451,6 +451,19 @@ QUnit.test('Call to read all cookies with mixed json', function (assert) {
 	assert.deepEqual(Cookies.get(), { c: '{"foo":"bar"}', c2: 'v' }, 'returns unparsed cookies');
 });
 
+QUnit.test('Cookies with escaped quotes in json', function (assert) {
+	Cookies.withConverter({
+		read: function (value) {
+			return value;
+		},
+		write: function (value) {
+			return value;
+		}
+	}).set('c', '"{ \\"foo\\": \\"bar\\" }"');
+	assert.deepEqual(Cookies.getJSON('c'), '{ "foo": "bar" }', 'returns JSON parsed cookie');
+	assert.deepEqual(Cookies.get('c'), '{ \\"foo\\": \\"bar\\" }', 'returns unparsed cookie');
+});
+
 QUnit.module('noConflict', lifecycle);
 
 QUnit.test('do not conflict with existent globals', function (assert) {

--- a/test/tests.js
+++ b/test/tests.js
@@ -451,7 +451,7 @@ QUnit.test('Call to read all cookies with mixed json', function (assert) {
 	assert.deepEqual(Cookies.get(), { c: '{"foo":"bar"}', c2: 'v' }, 'returns unparsed cookies');
 });
 
-QUnit.test('Cookies with escaped quotes in json', function (assert) {
+QUnit.test('Cookies with escaped quotes in json using raw converters', function (assert) {
 	Cookies.withConverter({
 		read: function (value) {
 			return value;


### PR DESCRIPTION
Fixes #363 

I am not sure why quotes are removed to begin with. A cookie might contain double quotes that were intended to be there. I think the lines should be removed altogether but this change fixes my problem.