### PR TITLE
Add CDN links

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
   <img src="https://cloud.githubusercontent.com/assets/835857/14581711/ba623018-0436-11e6-8fce-d2ccd4d379c9.gif">
 </p>
 
-# JavaScript Cookie [![Build Status](https://travis-ci.org/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.org/js-cookie/js-cookie) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie)
+# JavaScript Cookie [![Build Status](https://travis-ci.org/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.org/js-cookie/js-cookie) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/js-cookie/badge?style=rounded)](https://www.jsdelivr.com/package/npm/js-cookie)
 
 A simple, lightweight JavaScript API for handling cookies
 
@@ -32,6 +32,12 @@ Download the script [here](https://github.com/js-cookie/js-cookie/blob/latest/sr
 
 ```html
 <script src="/path/to/js.cookie.js"></script>
+```
+
+Or include it via [jsDelivr CDN](https://www.jsdelivr.com/package/npm/js-cookie):
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.js"></script>
 ```
 
 **Do not include the script directly from GitHub (http://raw.github.com/...).** The file is being served as text/plain and as such being blocked

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Download the script [here](https://github.com/js-cookie/js-cookie/blob/latest/sr
 Or include it via [jsDelivr CDN](https://www.jsdelivr.com/package/npm/js-cookie):
 
 ```html
-<script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.js"></script>
+<script src="https://cdn.jsdelivr.net/npm/js-cookie@2/src/js.cookie.min.js"></script>
 ```
 
 **Do not include the script directly from GitHub (http://raw.github.com/...).** The file is being served as text/plain and as such being blocked


### PR DESCRIPTION
I added jsDelivr CDN links to your readme to make it easier to use.
I also noticed that js-cookie gets 12M hits per month on jsDelivr, so I thought you might like this badge.