### PR TITLE
Add package-lock.json file to git ignored files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules
 build
+package-lock.json
 .sizecache.json
 *.log*


### PR DESCRIPTION
I think the `package-lock.json` file is better to be ignored? It was sitting in my repo as added when it seemingly shouldn't.