### PR TITLE
BrowserStack migration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
+addons:
+  browserstack:
+    username: ${BROWSERSTACK_USERNAME}
+    access_key: ${BROWSERSTACK_ACCESS_KEY}
+    forcelocal: true
 language: node_js
 node_js:
   - '6'
@@ -8,17 +13,10 @@ cache:
     - node_modules
 stages:
   - test
-  - name: saucelabs
-    if: fork IS false
+  - name: browserstack
+    if: env(BROWSERSTACK_USERNAME) IS present
 jobs:
   include:
-    - stage: saucelabs
+    - stage: browserstack
       node_js: '10'
-      script: grunt saucelabs
-      addons:
-        sauce_connect: true
-env:
-  # Encrypted SAUCE_USERNAME and SAUCE_ACCESS_KEY used by travis
-  global:
-    - secure: IkMOa/8r4sWyzUMxecsfqoPzZyIqVAMwPkQ6/HxXPbT8X7UnvqAdaicAMeHEKtOnOac+rx6pGB9HQvC8P/ZzkEBtsKLP4nEh9vsAInZvb3pXg+qbIgIK6/19X0kU4UkpDqVdWmBuFTamJvMDMstUTgEaM3869bB5vGp9taBgfVo=
-    - secure: DKrQplF0CBiBh+cbQ8D7EKebCeklUWEELblIJdU4475Occ4G9b8ZFYO9HFwl1B8F/XapB7CsMyxbJCWor030FySeqn8bhJs9NoAVoYGg+MtWniv1EOHuZLWuOGfgQDv7qj5U0Af9Y655MmUpXSN2aDlCmQweWnYdpFTM9Dfsdd8=
+      script: grunt browserstack

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -91,12 +91,6 @@ module.exports = function (grunt) {
 					}
 				}
 			},
-			'build-sauce': {
-				options: {
-					port: 9999,
-					base: ['.', 'test']
-				}
-			},
 			tests: {
 				options: {
 					port: 10000,
@@ -111,73 +105,8 @@ module.exports = function (grunt) {
 				}
 			}
 		},
-		'saucelabs-qunit': {
-			all: {
-				options: {
-					urls: ['http://127.0.0.1:9999'],
-					testname: 'Sauce Test for js-cookie',
-					build: process.env.TRAVIS_JOB_ID,
-					statusCheckAttempts: -1,
-					throttled: 3,
-					browsers: [
-						{
-							browserName: 'safari',
-							platform: 'macOS 10.13',
-							version: '12.0'
-						},
-						{
-							browserName: 'safari',
-							platform: 'macOS 10.13',
-							version: '11.1'
-						},
-						{
-							browserName: 'firefox',
-							platform: 'macOS 10.13',
-							version: '65.0'
-						},
-						{
-							browserName: 'chrome',
-							platform: 'macOS 10.13',
-							version: '72.0'
-						},
-						{
-							browserName: 'safari',
-							platform: 'macOS 10.12',
-							version: '11.0'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 10',
-							version: '11.285'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 7',
-							version: '11.0'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 7',
-							version: '10.0'
-						},
-						{
-							browserName: 'internet explorer',
-							platform: 'Windows 7',
-							version: '9.0'
-						},
-						{
-							browserName: 'firefox',
-							platform: 'Linux',
-							version: '45.0'
-						},
-						{
-							browserName: 'chrome',
-							platform: 'Linux',
-							version: '48.0'
-						}
-					]
-				}
-			}
+		exec: {
+			'browserstack-runner': 'node_modules/.bin/browserstack-runner --verbose'
 		}
 	});
 
@@ -189,7 +118,7 @@ module.exports = function (grunt) {
 	}
 
 	grunt.registerTask('test', ['uglify', 'eslint', 'connect:build-qunit', 'qunit', 'nodeunit']);
-	grunt.registerTask('saucelabs', ['uglify', 'connect:build-sauce', 'saucelabs-qunit']);
+	grunt.registerTask('browserstack', ['uglify', 'exec:browserstack-runner']);
 
 	grunt.registerTask('dev', ['test', 'compare_size']);
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="https://cloud.githubusercontent.com/assets/835857/14581711/ba623018-0436-11e6-8fce-d2ccd4d379c9.gif">
 </p>
 
-# JavaScript Cookie [![Build Status](https://travis-ci.org/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.org/js-cookie/js-cookie) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/js-cookie/badge?style=rounded)](https://www.jsdelivr.com/package/npm/js-cookie)
+# JavaScript Cookie [![Build Status](https://travis-ci.org/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.org/js-cookie/js-cookie) [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=Y2xZRXJTK0dxYXQ3RlVFOVJMbDF5cG9zaWVmTDJQWnVwcVdSSWlDdzY0VT0tLW5ZUzY1Y1oyQ3JtTm1ZSWpjRXlaVUE9PQ==--81a8196ff92a5833081d711db43c1e33dedcb3e3)](https://www.browserstack.com/automate/public-build/Y2xZRXJTK0dxYXQ3RlVFOVJMbDF5cG9zaWVmTDJQWnVwcVdSSWlDdzY0VT0tLW5ZUzY1Y1oyQ3JtTm1ZSWpjRXlaVUE9PQ==--81a8196ff92a5833081d711db43c1e33dedcb3e3) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/js-cookie/badge?style=rounded)](https://www.jsdelivr.com/package/npm/js-cookie)
 
 A simple, lightweight JavaScript API for handling cookies
 
-* Works in [all](https://saucelabs.com/u/js-cookie) browsers
+* Works in [all](https://www.browserstack.com/automate/public-build/Y2xZRXJTK0dxYXQ3RlVFOVJMbDF5cG9zaWVmTDJQWnVwcVdSSWlDdzY0VT0tLW5ZUzY1Y1oyQ3JtTm1ZSWpjRXlaVUE9PQ==--81a8196ff92a5833081d711db43c1e33dedcb3e3) browsers
 * Accepts [any](#encoding) character
 * [Heavily](test) tested
 * No dependency
@@ -19,10 +19,6 @@ A simple, lightweight JavaScript API for handling cookies
 
 **If you're viewing this at https://github.com/js-cookie/js-cookie, you're reading the documentation for the master branch.
 [View documentation for the latest release.](https://github.com/js-cookie/js-cookie/tree/latest#readme)**
-
-## Build Status Matrix ([including active Pull Requests](https://github.com/js-cookie/js-cookie/issues/286))
-
-[![Selenium Test Status](https://saucelabs.com/browser-matrix/js-cookie.svg)](https://saucelabs.com/u/js-cookie)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -316,6 +316,14 @@ For vulnerability reports, send an e-mail to `jscookieproject at gmail dot com`
   * `git push origin master --tags`
 * Release on npm
 
+## Supporters
+
+<p>
+  <a href="https://www.browserstack.com/"><img src="https://raw.githubusercontent.com/wiki/js-cookie/js-cookie/Browserstack-logo%402x.png" width="150"></a>
+</p>
+
+Many thanks to [BrowserStack](https://www.browserstack.com/) for providing unlimited browser testing free of cost.
+
 ## Authors
 
 * [Klaus Hartl](https://github.com/carhartl)

--- a/README.md
+++ b/README.md
@@ -2,11 +2,11 @@
   <img src="https://cloud.githubusercontent.com/assets/835857/14581711/ba623018-0436-11e6-8fce-d2ccd4d379c9.gif">
 </p>
 
-# JavaScript Cookie [![Build Status](https://travis-ci.org/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.org/js-cookie/js-cookie) [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=Y2xZRXJTK0dxYXQ3RlVFOVJMbDF5cG9zaWVmTDJQWnVwcVdSSWlDdzY0VT0tLW5ZUzY1Y1oyQ3JtTm1ZSWpjRXlaVUE9PQ==--81a8196ff92a5833081d711db43c1e33dedcb3e3)](https://www.browserstack.com/automate/public-build/Y2xZRXJTK0dxYXQ3RlVFOVJMbDF5cG9zaWVmTDJQWnVwcVdSSWlDdzY0VT0tLW5ZUzY1Y1oyQ3JtTm1ZSWpjRXlaVUE9PQ==--81a8196ff92a5833081d711db43c1e33dedcb3e3) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/js-cookie/badge?style=rounded)](https://www.jsdelivr.com/package/npm/js-cookie)
+# JavaScript Cookie [![Build Status](https://travis-ci.org/js-cookie/js-cookie.svg?branch=master)](https://travis-ci.org/js-cookie/js-cookie) [![BrowserStack Status](https://www.browserstack.com/automate/badge.svg?badge_key=QkpFeUZPS1d3cGVtdjIvUHR2VzNTTmQxbHdPUHc5RVFzbnpoZ3ZJWUFFYz0tLVhpSStmK2dpMG5OMDlpbGJBZzNxSEE9PQ==--7f5d9c7e35fed17bc6967cdb06bf79dc4d5bafd8 )](https://www.browserstack.com/automate/public-build/QkpFeUZPS1d3cGVtdjIvUHR2VzNTTmQxbHdPUHc5RVFzbnpoZ3ZJWUFFYz0tLVhpSStmK2dpMG5OMDlpbGJBZzNxSEE9PQ==--7f5d9c7e35fed17bc6967cdb06bf79dc4d5bafd8 ) [![Code Climate](https://codeclimate.com/github/js-cookie/js-cookie.svg)](https://codeclimate.com/github/js-cookie/js-cookie) [![jsDelivr Hits](https://data.jsdelivr.com/v1/package/npm/js-cookie/badge?style=rounded)](https://www.jsdelivr.com/package/npm/js-cookie)
 
 A simple, lightweight JavaScript API for handling cookies
 
-* Works in [all](https://www.browserstack.com/automate/public-build/Y2xZRXJTK0dxYXQ3RlVFOVJMbDF5cG9zaWVmTDJQWnVwcVdSSWlDdzY0VT0tLW5ZUzY1Y1oyQ3JtTm1ZSWpjRXlaVUE9PQ==--81a8196ff92a5833081d711db43c1e33dedcb3e3) browsers
+* Works in [all](https://www.browserstack.com/automate/public-build/QkpFeUZPS1d3cGVtdjIvUHR2VzNTTmQxbHdPUHc5RVFzbnpoZ3ZJWUFFYz0tLVhpSStmK2dpMG5OMDlpbGJBZzNxSEE9PQ==--7f5d9c7e35fed17bc6967cdb06bf79dc4d5bafd8 ) browsers
 * Accepts [any](#encoding) character
 * [Heavily](test) tested
 * No dependency

--- a/browserstack.json
+++ b/browserstack.json
@@ -1,29 +1,27 @@
 {
-    "test_framework" : "qunit",
-    "test_path": [
-        "test/index.html"
-    ],
-    "exit_with_fail": true,
-    "browsers": [
-        "chrome_latest",
-        "chrome_previous",
-        "firefox_latest",
-        "firefox_previous",
-        "ie_11",
-        "ie_10",
-        "ie_9",
-        "opera_latest",
-        {
-            "browser": "safari",
-            "browser_version": "latest",
-            "os": "OS X",
-            "os_version": "Mojave"
-        },
-        {
-            "browser": "safari",
-            "browser_version": "latest",
-            "os": "OS X",
-            "os_version": "High Sierra"
-        }
-    ]
+  "test_framework": "qunit",
+  "test_path": ["test/index.html"],
+  "exit_with_fail": true,
+  "browsers": [
+    "chrome_latest",
+    "chrome_previous",
+    "firefox_latest",
+    "firefox_previous",
+    "ie_11",
+    "ie_10",
+    "ie_9",
+    "opera_latest",
+    {
+      "browser": "safari",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "Mojave"
+    },
+    {
+      "browser": "safari",
+      "browser_version": "latest",
+      "os": "OS X",
+      "os_version": "High Sierra"
+    }
+  ]
 }

--- a/browserstack.json
+++ b/browserstack.json
@@ -1,0 +1,29 @@
+{
+    "test_framework" : "qunit",
+    "test_path": [
+        "test/index.html"
+    ],
+    "exit_with_fail": true,
+    "browsers": [
+        "chrome_latest",
+        "chrome_previous",
+        "firefox_latest",
+        "firefox_previous",
+        "ie_11",
+        "ie_10",
+        "ie_9",
+        "opera_latest",
+        {
+            "browser": "safari",
+            "browser_version": "latest",
+            "os": "OS X",
+            "os_version": "Mojave"
+        },
+        {
+            "browser": "safari",
+            "browser_version": "latest",
+            "os": "OS X",
+            "os_version": "High Sierra"
+        }
+    ]
+}

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   "author": "Klaus Hartl",
   "license": "MIT",
   "devDependencies": {
+    "browserstack-runner": "0.9.0",
     "grunt": "1.0.3",
     "grunt-compare-size": "0.4.2",
     "grunt-contrib-connect": "2.0.0",
@@ -39,7 +40,7 @@
     "grunt-contrib-uglify": "2.3.0",
     "grunt-contrib-watch": "1.1.0",
     "grunt-eslint": "21.0.0",
-    "grunt-saucelabs": "9.0.0",
+    "grunt-exec": "3.0.0",
     "gzip-js": "0.3.2",
     "qunitjs": "1.23.1",
     "requirejs": "2.3.5"

--- a/test/polyfill.js
+++ b/test/polyfill.js
@@ -9,3 +9,23 @@ Array.prototype.forEach||(Array.prototype.forEach=function(a,b){var c,d;if(null=
 // JSON
 // github.com/douglascrockford/JSON-js/tree/c07c287e39ab5a1726818e0436490bf071b7c838
 "object"!=typeof JSON&&(JSON={}),function(){"use strict";function f(a){return 10>a?"0"+a:a}function this_value(){return this.valueOf()}function quote(a){return escapable.lastIndex=0,escapable.test(a)?'"'+a.replace(escapable,function(a){var b=meta[a];return"string"==typeof b?b:"\\u"+("0000"+a.charCodeAt(0).toString(16)).slice(-4)})+'"':'"'+a+'"'}function str(a,b){var c,d,e,f,h,g=gap,i=b[a];switch(i&&"object"==typeof i&&"function"==typeof i.toJSON&&(i=i.toJSON(a)),"function"==typeof rep&&(i=rep.call(b,a,i)),typeof i){case"string":return quote(i);case"number":return isFinite(i)?String(i):"null";case"boolean":case"null":return String(i);case"object":if(!i)return"null";if(gap+=indent,h=[],"[object Array]"===Object.prototype.toString.apply(i)){for(f=i.length,c=0;f>c;c+=1)h[c]=str(c,i)||"null";return e=0===h.length?"[]":gap?"[\n"+gap+h.join(",\n"+gap)+"\n"+g+"]":"["+h.join(",")+"]",gap=g,e}if(rep&&"object"==typeof rep)for(f=rep.length,c=0;f>c;c+=1)"string"==typeof rep[c]&&(d=rep[c],e=str(d,i),e&&h.push(quote(d)+(gap?": ":":")+e));else for(d in i)Object.prototype.hasOwnProperty.call(i,d)&&(e=str(d,i),e&&h.push(quote(d)+(gap?": ":":")+e));return e=0===h.length?"{}":gap?"{\n"+gap+h.join(",\n"+gap)+"\n"+g+"}":"{"+h.join(",")+"}",gap=g,e}}"function"!=typeof Date.prototype.toJSON&&(Date.prototype.toJSON=function(){return isFinite(this.valueOf())?this.getUTCFullYear()+"-"+f(this.getUTCMonth()+1)+"-"+f(this.getUTCDate())+"T"+f(this.getUTCHours())+":"+f(this.getUTCMinutes())+":"+f(this.getUTCSeconds())+"Z":null},Boolean.prototype.toJSON=this_value,Number.prototype.toJSON=this_value,String.prototype.toJSON=this_value);var cx,escapable,gap,indent,meta,rep;"function"!=typeof JSON.stringify&&(escapable=/[\\\"\u0000-\u001f\u007f-\u009f\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,meta={"\b":"\\b","	":"\\t","\n":"\\n","\f":"\\f","\r":"\\r",'"':'\\"',"\\":"\\\\"},JSON.stringify=function(a,b,c){var d;if(gap="",indent="","number"==typeof c)for(d=0;c>d;d+=1)indent+=" ";else"string"==typeof c&&(indent=c);if(rep=b,b&&"function"!=typeof b&&("object"!=typeof b||"number"!=typeof b.length))throw new Error("JSON.stringify");return str("",{"":a})}),"function"!=typeof JSON.parse&&(cx=/[\u0000\u00ad\u0600-\u0604\u070f\u17b4\u17b5\u200c-\u200f\u2028-\u202f\u2060-\u206f\ufeff\ufff0-\uffff]/g,JSON.parse=function(text,reviver){function walk(a,b){var c,d,e=a[b];if(e&&"object"==typeof e)for(c in e)Object.prototype.hasOwnProperty.call(e,c)&&(d=walk(e,c),void 0!==d?e[c]=d:delete e[c]);return reviver.call(a,b,e)}var j;if(text=String(text),cx.lastIndex=0,cx.test(text)&&(text=text.replace(cx,function(a){return"\\u"+("0000"+a.charCodeAt(0).toString(16)).slice(-4)})),/^[\],:{}\s]*$/.test(text.replace(/\\(?:["\\\/bfnrt]|u[0-9a-fA-F]{4})/g,"@").replace(/"[^"\\\n\r]*"|true|false|null|-?\d+(?:\.\d*)?(?:[eE][+\-]?\d+)?/g,"]").replace(/(?:^|:|,)(?:\s*\[)+/g,"")))return j=eval("("+text+")"),"function"==typeof reviver?walk({"":j},""):j;throw new SyntaxError("JSON.parse")})}();
+
+// Console-polyfill. MIT license.
+// https://github.com/paulmillr/console-polyfill
+// Make it safe to do console.log() always.
+(function(global) {
+  'use strict';
+  if (!global.console) {
+    global.console = {};
+  }
+  var con = global.console;
+  var prop, method;
+  var dummy = function() {};
+  var properties = ['memory'];
+  var methods = ('assert,clear,count,debug,dir,dirxml,error,exception,group,' +
+     'groupCollapsed,groupEnd,info,log,markTimeline,profile,profiles,profileEnd,' +
+     'show,table,time,timeEnd,timeline,timelineEnd,timeStamp,trace,warn').split(',');
+  while (prop = properties.pop()) if (!con[prop]) con[prop] = {};
+  while (method = methods.pop()) if (!con[method]) con[method] = dummy;
+  // Using `this` for web workers & supports Browserify / Webpack.
+})(typeof window === 'undefined' ? this : window);

--- a/test/tests.js
+++ b/test/tests.js
@@ -117,7 +117,7 @@ QUnit.test('Call to read cookie when there is another unrelated cookie with malf
 	document.cookie = 'c=v';
 	assert.strictEqual(Cookies.get('c'), 'v', 'should not throw a URI malformed exception when retrieving a single cookie');
 	assert.deepEqual(Cookies.get(), { c: 'v' }, 'should not throw a URI malformed exception when retrieving all cookies');
-	Cookies.withConverter(unescape).remove('invalid');
+	document.cookie = 'invalid=foo; expires=Thu, 01 Jan 1970 00:00:00 GMT';
 });
 
 // github.com/js-cookie/js-cookie/issues/145

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,36 +1,5 @@
-// https://github.com/axemclion/grunt-saucelabs#test-result-details-with-qunit
 (function () {
 	'use strict';
-
-	var log = [];
-
-	QUnit.done(function (test_results) {
-		var tests = [];
-		for (var i = 0, len = log.length; i < len; i++) {
-			var details = log[i];
-			tests.push({
-				name: details.name,
-				result: details.result,
-				expected: details.expected,
-				actual: details.actual,
-				source: details.source
-			});
-		}
-		test_results.tests = tests;
-		// Required for exposing test results to the Sauce Labs API.
-		// Can be removed when the following issue is fixed:
-		// https://github.com/axemclion/grunt-saucelabs/issues/84
-		window.global_test_results = test_results;
-	});
-
-	QUnit.testStart(function (testDetails) {
-		QUnit.log(function (details) {
-			if (!details.result) {
-				details.name = testDetails.name;
-				log.push(details);
-			}
-		});
-	});
 
 	window.lifecycle = {
 		afterEach: function () {


### PR DESCRIPTION
Moving from Saucelabs to BrowserStack ~, so we can automate testing in prehistoric Internet Explorers (6 + 7) again~. BrowserStack kindly provides access for open-source projects ❤️

Overall using BrowserStack seems a little more streamlined (removing code!).

- [x] Travis/Grunt setup
- [x] Finalize list of browsers to test in (=> `browserstack.json`)
- [x] Adapt readme (badge)
- [x] Add shoutout
