### PR TITLE
Fix getJSON() accidentally writing cookie with too many arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,16 @@ Read all visible cookies:
 Cookies.get(); // => { name: 'value' }
 ```
 
+*Note: It is not possible to read a particular cookie by passing one of the cookie attributes (which may or may not
+have been used when writing the cookie in question):*
+
+```javascript
+Cookies.get('foo', domain: { 'sub.example.com' }); // `domain` won't have any effect...!
+```
+
+The cookie with the name `foo` will only be available on `.get()` if it's visible from where the
+code is called; the domain and/or path attribute will not have an effect when reading.
+
 Delete cookie:
 
 ```javascript

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -140,10 +140,10 @@
 		api.get = function (key) {
 			return api.call(api, key);
 		};
-		api.getJSON = function () {
-			return api.apply({
+		api.getJSON = function (key) {
+			return api.call({
 				json: true
-			}, arguments);
+			}, key);
 		};
 		api.remove = function (key, attributes) {
 			api(key, '', extend(attributes, {

--- a/test/tests.js
+++ b/test/tests.js
@@ -474,6 +474,11 @@ QUnit.test('Cookies with escaped quotes in json using raw converters', function 
 	assert.strictEqual(Cookies.get('c'), '{ \\"foo\\": \\"bar\\" }', 'returns unparsed cookie with enclosing quotes removed');
 });
 
+QUnit.test('Prevent accidentally writing cookie when passing unexpected argument', function (assert) {
+	Cookies.getJSON('c', { foo: 'bar' });
+	assert.strictEqual(Cookies.get('c'), undefined, 'should not write any cookie');
+});
+
 QUnit.module('noConflict', lifecycle);
 
 QUnit.test('do not conflict with existent globals', function (assert) {


### PR DESCRIPTION
Addresses #417 (for context see there).

- [x] Fix implementation
- [x] Brushup documentation

~Note: I needed to change a test (see e22693488a6c31e9f54d5f4734b92968ace8ea2e), unrelated to the PR, because it was failing due to upcoming DST change, and the expires date was lying after that change, resulting in a date string mismatch. I reduced the likelihood of this happening again by reducing the amount of days expires will be ahead of "now", but there should be a way how to make this proof once and for all.~[-> commit went out of PR to master]