### PR TITLE
Make expires test agnostic to DST change

### DIFF
--- a/test/tests.js
+++ b/test/tests.js
@@ -180,10 +180,10 @@ QUnit.test('undefined', function (assert) {
 
 QUnit.test('expires option as days from now', function (assert) {
 	assert.expect(1);
-	var expires = new Date();
-	expires.setDate(expires.getDate() + 1);
+	var days = 200;
+	var expires = new Date(new Date().valueOf() + days * 24 * 60 * 60 * 1000);
 	var expected = 'expires=' + expires.toUTCString();
-	var actual = Cookies.set('c', 'v', { expires: 1 });
+	var actual = Cookies.set('c', 'v', { expires: days });
 	assert.ok(actual.indexOf(expected) !== -1, quoted(actual) + ' includes ' + quoted(expected));
 });
 


### PR DESCRIPTION
The test setup itself was assuming a different implementation. While `setDate()` will respect values causing the new date to overlap a DST change, e.g. adapt the hour accordingly, the underlying implementation does not. Therefore we need to set up the expected date to assert for differently, in line with the implementation that is.

Closes #419

