### PR TITLE
[RFC] Generate CommonJS and ESM versions of JSCookie along with the UMD version.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -30,5 +30,11 @@
     "no-array-constructor": "error",
     "no-new-object": "error",
     "no-new-wrappers": "error"
-  }
+  },
+  "overrides": [{
+    "files": ["rollup.config.js"],
+    "parserOptions": {
+      "sourceType": "module"
+    }
+  }]
 }

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -42,6 +42,7 @@ module.exports = function (grunt) {
 		},
 		eslint: {
 			grunt: 'Gruntfile.js',
+			rollup: 'rollup.config.js',
 			source: 'src/**/*.js',
 			tests: ['test/**/*.js', '!test/polyfill.js']
 		},
@@ -55,8 +56,9 @@ module.exports = function (grunt) {
 			},
 			build: {
 				files: {
-					'build/js.cookie.min.js': 'src/js.cookie.js',
-					'build/js.cookie-<%= pkg.version %>.min.js': 'src/js.cookie.js'
+					'build/js.cookie.min.js': 'lib/js.cookie.umd.js',
+					'build/js.cookie-<%= pkg.version %>.min.js': 'lib/js.cookie.umd.js',
+					'build/js.cookie.cjs.min.js': 'lib/js.cookie.js',
 				}
 			}
 		},
@@ -70,7 +72,10 @@ module.exports = function (grunt) {
 		compare_size: {
 			files: [
 				'build/js.cookie-<%= pkg.version %>.min.js',
-				'src/js.cookie.js'
+				'build/js.cookie.cjs.min.js',
+				'lib/js.cookie.js',
+				'lib/js.cookie.umd.js',
+				'lib/js.cookie.esm.js'
 			],
 			options: {
 				compress: {

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "js-cookie",
   "license": "MIT",
   "main": [
-    "src/js.cookie.js"
+    "lib/js.cookie.umd.js"
   ],
   "ignore": [
     "travis.sh",

--- a/lib/js.cookie.esm.js
+++ b/lib/js.cookie.esm.js
@@ -1,3 +1,10 @@
+/*!
+ * JavaScript Cookie v2.2.0
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
 function extend () {
 	var i = 0;
 	var result = {};
@@ -133,6 +140,6 @@ function init (converter) {
 	return api;
 }
 
-var JSCookie = init(function () {});;
+var JSCookie = init(function () {});
 
 export default JSCookie;

--- a/lib/js.cookie.js
+++ b/lib/js.cookie.js
@@ -1,3 +1,12 @@
+/*!
+ * JavaScript Cookie v2.2.0
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+'use strict';
+
 function extend () {
 	var i = 0;
 	var result = {};
@@ -133,6 +142,6 @@ function init (converter) {
 	return api;
 }
 
-var JSCookie = init(function () {});;
+var JSCookie = init(function () {});
 
-export default JSCookie;
+module.exports = JSCookie;

--- a/lib/js.cookie.umd.js
+++ b/lib/js.cookie.umd.js
@@ -1,0 +1,158 @@
+/*!
+ * JavaScript Cookie v2.2.0
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(function() {
+		var current = global.Cookies;
+		var exports = factory();
+		global.Cookies = exports;
+		exports.noConflict = function() { global.Cookies = current; return exports; };
+	})();
+}(this, (function () { 'use strict';
+
+	function extend () {
+		var i = 0;
+		var result = {};
+		for (; i < arguments.length; i++) {
+			var attributes = arguments[ i ];
+			for (var key in attributes) {
+				result[key] = attributes[key];
+			}
+		}
+		return result;
+	}
+
+	function decode (s) {
+		return s.replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent);
+	}
+
+	function init (converter) {
+		function api() {}
+
+		function set (key, value, attributes) {
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			attributes = extend({
+				path: '/'
+			}, api.defaults, attributes);
+
+			if (typeof attributes.expires === 'number') {
+				attributes.expires = new Date(new Date() * 1 + attributes.expires * 864e+5);
+			}
+
+			// We're using "expires" because "max-age" is not supported by IE
+			attributes.expires = attributes.expires ? attributes.expires.toUTCString() : '';
+
+			try {
+				var result = JSON.stringify(value);
+				if (/^[\{\[]/.test(result)) {
+					value = result;
+				}
+			} catch (e) {}
+
+			value = converter.write ?
+				converter.write(value, key) :
+				encodeURIComponent(String(value))
+					.replace(/%(23|24|26|2B|3A|3C|3E|3D|2F|3F|40|5B|5D|5E|60|7B|7D|7C)/g, decodeURIComponent);
+
+			key = encodeURIComponent(String(key))
+				.replace(/%(23|24|26|2B|5E|60|7C)/g, decodeURIComponent)
+				.replace(/[\(\)]/g, escape);
+
+			var stringifiedAttributes = '';
+			for (var attributeName in attributes) {
+				if (!attributes[attributeName]) {
+					continue;
+				}
+				stringifiedAttributes += '; ' + attributeName;
+				if (attributes[attributeName] === true) {
+					continue;
+				}
+
+				// Considers RFC 6265 section 5.2:
+				// ...
+				// 3.  If the remaining unparsed-attributes contains a %x3B (";")
+				//     character:
+				// Consume the characters of the unparsed-attributes up to,
+				// not including, the first %x3B (";") character.
+				// ...
+				stringifiedAttributes += '=' + attributes[attributeName].split(';')[0];
+			}
+
+			return (document.cookie = key + '=' + value + stringifiedAttributes);
+		}
+
+		function get (key, json) {
+			if (typeof document === 'undefined') {
+				return;
+			}
+
+			var jar = {};
+			// To prevent the for loop in the first place assign an empty array
+			// in case there are no cookies at all.
+			var cookies = document.cookie ? document.cookie.split('; ') : [];
+			var i = 0;
+
+			for (; i < cookies.length; i++) {
+				var parts = cookies[i].split('=');
+				var cookie = parts.slice(1).join('=');
+
+				if (!json && cookie.charAt(0) === '"') {
+					cookie = cookie.slice(1, -1);
+				}
+
+				try {
+					var name = decode(parts[0]);
+					cookie = (converter.read || converter)(cookie, name) ||
+						decode(cookie);
+
+					if (json) {
+						try {
+							cookie = JSON.parse(cookie);
+						} catch (e) {}
+					}
+
+					jar[name] = cookie;
+
+					if (key === name) {
+						break;
+					}
+				} catch (e) {}
+			}
+
+			return key ? jar[key] : jar;
+		}
+
+		api.set = set;
+		api.get = function (key) {
+			return get(key, false /* read as raw */);
+		};
+		api.getJSON = function (key) {
+			return get(key, true /* read as json */);
+		};
+		api.remove = function (key, attributes) {
+			set(key, '', extend(attributes, {
+				expires: -1
+			}));
+		};
+
+		api.defaults = {};
+
+		api.withConverter = init;
+
+		return api;
+	}
+
+	var JSCookie = init(function () {});
+
+	return JSCookie;
+
+})));

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "js-cookie",
   "version": "2.2.0",
   "description": "A simple, lightweight JavaScript API for handling cookies",
-  "main": "src/js.cookie.js",
+  "main": "lib/js.cookie.js",
   "directories": {
     "test": "test"
   },
@@ -18,14 +18,15 @@
     "browserify"
   ],
   "scripts": {
-    "test": "grunt test"
+    "test": "npm run build && grunt test",
+    "build": "rollup -c"
   },
   "repository": {
     "type": "git",
     "url": "git://github.com/js-cookie/js-cookie.git"
   },
   "files": [
-    "src/**/*.js",
+    "lib/**/*.js",
     "SERVER_SIDE.md",
     "CONTRIBUTING.md"
   ],
@@ -43,6 +44,7 @@
     "grunt-saucelabs": "9.0.0",
     "gzip-js": "0.3.2",
     "qunitjs": "1.23.1",
-    "requirejs": "2.3.5"
+    "requirejs": "2.3.5",
+    "rollup": "^0.62.0"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,0 +1,32 @@
+import pkg from './package.json';
+
+const banner = `/*!
+ * JavaScript Cookie v2.2.0
+ * https://github.com/js-cookie/js-cookie
+ *
+ * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
+ * Released under the MIT license
+ */`;
+
+export default {
+	output: [
+		{
+			file: 'lib/js.cookie.umd.js',
+			format: 'umd',
+			name: 'Cookies',
+			noConflict: true,
+			banner
+		},
+		{
+			file: pkg.main,
+			format: 'cjs',
+			banner
+		},
+		{
+			file: 'lib/js.cookie.esm.js',
+			format: 'esm',
+			banner
+		}
+	],
+	input: 'src/js.cookie.js'
+};

--- a/src/.eslintrc
+++ b/src/.eslintrc
@@ -1,10 +1,12 @@
 {
   "extends": "../.eslintrc",
   "env": {
-    "browser": true,
-    "amd": true
+    "browser": true
   },
   "rules": {
     "camelcase": "error"
+  },
+  "parserOptions": {
+    "sourceType": "module"
   }
 }

--- a/test/amd.js
+++ b/test/amd.js
@@ -5,7 +5,7 @@ require(['qunit'], function (QUnit) {
 	QUnit.test('module loading', function (assert) {
 		assert.expect(1);
 		var done = assert.async();
-		require(['/src/js.cookie.js'], function (Cookies) {
+		require(['/lib/js.cookie.umd.js'], function (Cookies) {
 			assert.ok(!!Cookies.get, 'should load the api');
 			done();
 		});

--- a/test/encoding.html
+++ b/test/encoding.html
@@ -5,7 +5,7 @@
 		<title>JavaScript Cookie Test Suite - Encoding</title>
 		<link href="../node_modules/qunitjs/qunit/qunit.css" rel="stylesheet">
 		<script src="../node_modules/qunitjs/qunit/qunit.js"></script>
-		<script src="../src/js.cookie.js"></script>
+		<script src="../lib/js.cookie.umd.js"></script>
 		<script src="utils.js"></script>
 		<script src="encoding.js"></script>
 	</head>

--- a/test/environment-with-amd-and-umd.js
+++ b/test/environment-with-amd-and-umd.js
@@ -16,7 +16,7 @@ require(['qunit'], function (QUnit) {
 	QUnit.test('js-cookie need to register itself in AMD and UMD', function (assert) {
 		assert.expect(2);
 		var done = assert.async();
-		require(['/src/js.cookie.js'], function () {
+		require(['/lib/js.cookie.umd.js'], function () {
 			var actual = typeof window.module.exports;
 			var expected = 'function';
 			assert.strictEqual(actual, expected, 'should register a function in module.exports');

--- a/test/node.js
+++ b/test/node.js
@@ -2,26 +2,26 @@
 exports.node = {
 	should_load_js_cookie: function (test) {
 		test.expect(1);
-		var Cookies = require('../src/js.cookie');
+		var Cookies = require('../lib/js.cookie');
 		test.ok(!!Cookies.get, 'should load the Cookies API');
 		test.done();
 	},
 	should_not_throw_error_for_set_call_in_node: function (test) {
 		test.expect(0);
-		var Cookies = require('../src/js.cookie');
+		var Cookies = require('../lib/js.cookie');
 		Cookies.set('anything');
 		Cookies.set('anything', { path: '' });
 		test.done();
 	},
 	should_not_throw_error_for_get_call_in_node: function (test) {
 		test.expect(0);
-		var Cookies = require('../src/js.cookie');
+		var Cookies = require('../lib/js.cookie');
 		Cookies.get('anything');
 		test.done();
 	},
 	should_not_throw_error_for_remove_call_in_node: function (test) {
 		test.expect(0);
-		var Cookies = require('../src/js.cookie');
+		var Cookies = require('../lib/js.cookie');
 		Cookies.remove('anything');
 		Cookies.remove('anything', { path: '' });
 		test.done();


### PR DESCRIPTION
Caveats up front: this is not quite done (but working) and would obviously require a major release. Together with #370 it could make for a nice major release.

The idea here is to keep the source code as an ESM and then use rollup to generate ESM, CommonJS and UMD modules. The major benefit is that the CJS and ESM versions allow users who use Webpack/Rollup/Parcel to save some bytes and some function invocations on startup, which improves startup time.

The UMD build generated by rollup is 9 bytes large then what's currently in master. I think that's an acceptable tradeoff considering how much everyone who uses a bundler saves.

I've included the ESM version in this PR, I'd back it out before merging (or at least not include it in the `package.json`) as the introp between ESM default exports and CommonJS is still not there.

Things that'd are left do:

- [ ] Update docs
- [ ] Remove ESM version
- [ ] Write changelog (maybe)
- [ ] Integrate with grunt watch (maybe)
- [ ] Make sure Travis rejects PRs that didn't update `lib/`

WDYT?