### PR TITLE
problem with decode regexp

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -37,7 +37,7 @@
 	}
 
 	function decode (s) {
-		return s.replace(/(%[0-9A-Z]{2})+/g, decodeURIComponent);
+		return s.replace(/(%[0-9A-Z]{2})+/gi, decodeURIComponent);
 	}
 
 	function init (converter) {


### PR DESCRIPTION
Hi, I found a problem in case, when to me from the back-end comes a cookie query-string like, where a part of the value is encoded in Cyrillic and is presented in lower case.

<img width="960" alt="2018-09-12 22 58 14" src="https://user-images.githubusercontent.com/3502507/45451256-3d796f00-b6e3-11e8-8fef-2275b042a106.png">

I could not understand why the `get()` method returns `undefined`.

A little debugged made the situation clear - RegExp used in decodeURIComponent matches only lowerCase parts, therefore inside `decode()` function is throw an error `URI malformed` (because of an incorrect string).

![image](https://user-images.githubusercontent.com/3502507/45451299-597d1080-b6e3-11e8-883e-a47f2068f2b8.png)
<img width="960" alt="2018-09-12 22 58 27" src="https://user-images.githubusercontent.com/3502507/45451312-6699ff80-b6e3-11e8-975c-497a82ddaa47.png">

So I send you my PR with a simple solution to this problem.