### PR TITLE
JS-Cookie:Removed PhantomJS Dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "grunt-compare-size": "0.4.2",
     "grunt-contrib-connect": "1.0.2",
     "grunt-contrib-nodeunit": "2.0.0",
-    "grunt-contrib-qunit": "2.0.0",
+    "grunt-contrib-qunit": "3.0.1",
     "grunt-contrib-uglify": "2.3.0",
     "grunt-contrib-watch": "1.1.0",
     "grunt-eslint": "21.0.0",


### PR DESCRIPTION
PhantomJS is an unmaintained project, Updated grunt-contrib-qunit version to 3.0.1 in package.json to remove phantomjs dependency and use Headless Chrome Instead.

Signed-off-by: ossdev <ossdev@puresoftware.com>