### PR TITLE
API Call to Check cookies are enabled

### DIFF
--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -139,6 +139,15 @@
 			return key ? jar[key] : jar;
 		}
 
+		function isEnabled() {
+			var testKey = 'js-cookie.js';
+			api.set(testKey, 1, {});
+			var testCookie = api.get(testKey);
+			var isEnabled = (testCookie !== undefined);
+			api.remove(testKey);
+			return isEnabled;
+		}
+
 		api.set = set;
 		api.get = function (key) {
 			return get(key, false /* read as raw */);
@@ -151,6 +160,8 @@
 				expires: -1
 			}));
 		};
+
+		api.enabled = isEnabled();
 
 		api.defaults = {};
 

--- a/src/js.cookie.js
+++ b/src/js.cookie.js
@@ -139,15 +139,6 @@
 			return key ? jar[key] : jar;
 		}
 
-		function isEnabled() {
-			var testKey = 'js-cookie.js';
-			api.set(testKey, 1, {});
-			var testCookie = api.get(testKey);
-			var isEnabled = (testCookie !== undefined);
-			api.remove(testKey);
-			return isEnabled;
-		}
-
 		api.set = set;
 		api.get = function (key) {
 			return get(key, false /* read as raw */);
@@ -161,7 +152,14 @@
 			}));
 		};
 
-		api.enabled = isEnabled();
+		api.enabled = function() {
+			var testKey = 'js-cookie.js';
+			api.set(testKey, 1, {});
+			var testCookie = api.get(testKey);
+			var isEnabled = (testCookie !== undefined);
+			api.remove(testKey);
+			return isEnabled;
+		};
 
 		api.defaults = {};
 

--- a/test/tests.js
+++ b/test/tests.js
@@ -490,3 +490,11 @@ QUnit.test('do not conflict with existent globals', function (assert) {
 	assert.strictEqual(window.Cookies, 'existent global', 'should restore the original global');
 	window.Cookies = Cookies;
 });
+
+QUnit.module('enabled', lifecycle);
+
+QUnit.test('check that cookies are enabled', function (assert) {
+	assert.expect(1);
+	var isEnabled = Cookies.enabled;
+	assert.strictEqual(isEnabled, true, 'browser has not disabled cookies');
+});

--- a/test/tests.js
+++ b/test/tests.js
@@ -495,6 +495,6 @@ QUnit.module('enabled', lifecycle);
 
 QUnit.test('check that cookies are enabled', function (assert) {
 	assert.expect(1);
-	var isEnabled = Cookies.enabled;
+	var isEnabled = Cookies.enabled();
 	assert.strictEqual(isEnabled, true, 'browser has not disabled cookies');
 });


### PR DESCRIPTION
Running "uglify:build" (uglify) task
>> 2 files created 8.22 kB → 3.54 kB

Running "eslint:grunt" (eslint) task

Running "eslint:source" (eslint) task

Running "eslint:tests" (eslint) task

Running "connect:build-qunit" (connect) task
Started connect web server on http://localhost:9998

Running "qunit:all" (qunit) task
Testing http://127.0.0.1:9998/ ....................................................OK
Testing http://127.0.0.1:9998/amd.html .OK
Testing http://127.0.0.1:9998/environment-with-amd-and-umd.html .OK
Testing http://127.0.0.1:9998/encoding.html?integration_baseurl=http://127.0.0.1:9998/ ...............................................................OK
>> 117 tests completed with 0 failed, 0 skipped, and 0 todo. 
>> 196 assertions (in 1606ms), passed: 196, failed: 0

Running "nodeunit:all" (nodeunit) task
Testing node.js....OK
>> 1 assertions passed (11ms)

Running "compare_size:files" (compare_size) task
   raw     gz Sizes                                                            
  1769    905 build/js.cookie-2.2.0.min.js                                     
  4109   1597 src/js.cookie.js                                                 

   raw     gz Compared to master @ d62645185a4ede39ae10216fa695e5f70e701482    
  +127    +44 build/js.cookie-2.2.0.min.js                                     
  +226    +71 src/js.cookie.js                                                 

   raw     gz Compared to last run                                             
     =      = build/js.cookie-2.2.0.min.js                                     
     =      = src/js.cookie.js                                                 

Saved as: check-cookies-are-enabled

Done.