### PR TITLE
Automate releasing

### DIFF
--- a/.release-it.json
+++ b/.release-it.json
@@ -1,0 +1,5 @@
+{
+  "github": {
+    "release": true
+  }
+}

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,5 +1,19 @@
 {
+  "git": {
+    "commitMessage": "Craft v${version} release",
+    "requireCleanWorkingDir": false,
+    "tagAnnotation": "Release v${version}",
+    "tagName": "v${version}"
+  },
   "github": {
-    "release": true
+    "assets": ["dist/*.mjs", "dist/*.js"],
+    "draft": true,
+    "release": true,
+    "releaseName": "v${version}"
+  },
+  "hooks": {
+    "after:bump": "npm run dist",
+    "after:release": "echo Successfully released ${name} v${version} to ${repo.repository}.",
+    "before:init": "npm test"
   }
 }

--- a/.release-it.json
+++ b/.release-it.json
@@ -14,7 +14,7 @@
   },
   "hooks": {
     "after:bump": "npm run dist",
-    "after:release": "echo Successfully released ${name} v${version} to ${repo.repository}.",
+    "after:release": "echo Successfully created a release draft v${version} for ${repo.repository}. Please add release notes when necessary and publish it!",
     "before:init": "npm test"
   }
 }

--- a/.release-it.json
+++ b/.release-it.json
@@ -1,5 +1,6 @@
 {
   "git": {
+    "changelog": null,
     "commitMessage": "Craft v${version} release",
     "requireCleanWorkingDir": false,
     "tagAnnotation": "Release v${version}",

--- a/README.md
+++ b/README.md
@@ -344,6 +344,9 @@ Do a real release (publishes both to npm as well as create a new release on GitH
 $ npm run release minor
 ```
 
+_GitHub releases are created as a draft and need to be published manually!
+(This is so we are able to craft suitable release notes before publishing.)_
+
 ## Supporters
 
 <p>

--- a/README.md
+++ b/README.md
@@ -328,19 +328,21 @@ Check out the [Contributing Guidelines](CONTRIBUTING.md)
 
 For vulnerability reports, send an e-mail to `jscookieproject at gmail dot com`
 
-## Manual release steps
+## Releasing
 
-- Increment the "version" attribute of `package.json`
-- Increment the version number in the `src/js.cookie.mjs` file
-- If `major` bump, update jsDelivr CDN major version link on README
-- Commit with the message "Release version x.x.x"
-- Create version tag in git
-- Create a github release and upload the minified file
-- Change the `latest` tag pointer to the latest commit
-  - `git tag -f latest`
-  - `git push <remote> :refs/tags/latest`
-  - `git push origin master --tags`
-- Release on npm
+We are using [release-it](https://www.npmjs.com/package/release-it) for automated releasing.
+
+Start a dry run to see what would happen:
+
+```
+$ npm run release minor -- --dry-run
+```
+
+Do a real release (publishes both to npm as well as create a new release on GitHub):
+
+```
+$ npm run release minor
+```
 
 ## Supporters
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "test": "grunt test",
     "format": "standard --fix && prettier -l --write --single-quote --no-semi '**/*.{html,json,md}' && eslint '**/*.{html,md}' --fix",
+    "dist": "rm -rf dist/* && rollup -c",
     "release": "release-it"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   ],
   "scripts": {
     "test": "grunt test",
-    "format": "standard --fix && prettier -l --write --single-quote --no-semi '**/*.{html,json,md}' && eslint '**/*.{html,md}' --fix"
+    "format": "standard --fix && prettier -l --write --single-quote --no-semi '**/*.{html,json,md}' && eslint '**/*.{html,md}' --fix",
+    "release": "release-it"
   },
   "repository": {
     "type": "git",
@@ -48,6 +49,7 @@
     "gzip-js": "0.3.2",
     "prettier": "1.18.2",
     "qunit": "2.9.2",
+    "release-it": "^12.3.6",
     "rollup": "^1.20.3",
     "rollup-plugin-filesize": "^6.2.0",
     "rollup-plugin-license": "^0.12.1",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,14 @@ import { terser } from 'rollup-plugin-terser'
 import filesize from 'rollup-plugin-filesize'
 import license from 'rollup-plugin-license'
 
+const licenseBanner = license({
+  banner: {
+    content:
+      '/*! <%= pkg.name %> v<%= pkg.version %> | <%= pkg.license %> */',
+    commentStyle: 'none'
+  }
+})
+
 export default [
   {
     input: 'src/js.cookie.mjs',
@@ -21,6 +29,9 @@ export default [
         noConflict: true,
         banner: ';'
       }
+    ],
+    plugins: [
+      licenseBanner
     ]
   },
   {
@@ -43,13 +54,7 @@ export default [
     ],
     plugins: [
       terser(),
-      license({
-        banner: {
-          content:
-            '/*! <%= pkg.name %> v<%= pkg.version %> | <%= pkg.license %> */',
-          commentStyle: 'none'
-        }
-      }),
+      licenseBanner, // must be applied after terser, otherwise it's being stripped away...
       filesize()
     ]
   }

--- a/src/js.cookie.mjs
+++ b/src/js.cookie.mjs
@@ -1,10 +1,3 @@
-/*!
- * JavaScript Cookie v2.2.1
- * https://github.com/js-cookie/js-cookie
- *
- * Copyright 2006, 2015 Klaus Hartl & Fagner Brack
- * Released under the MIT license
- */
 function extend () {
   var i = 0
   var result = {}


### PR DESCRIPTION
Another part of the ongoing effort of modernizing the codebase. Since we now need to provide different variants/distributions of the library (module/nonmodule including minified versions), we aim for fully automating publishing to npm, as to avoid errors during the process.

We start using [release-it](https://www.npmjs.com/package/release-it) for fully automating both publishing to npm as well as creating releases on GitHub. Those GitHub releases do contain the minified sources, thus we're able to address #501.

- [x] Set up release-it
- [x] Adapt readme
