### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ _IMPORTANT! When deleting a cookie and you're not relying on the [default attrib
 Cookies.remove('name', { path: '', domain: '.yourdomain.com' })
 ```
 
-_Note: Removing a nonexistent cookie does not raise any exception nor return any value._
+_Note: Removing a nonexistent cookie neither raises any exception nor returns any value._
 
 ## Namespace conflicts
 


### PR DESCRIPTION
English Grammar-wise enhancements.
Neither-nor are used together. The word 'nor' is not used separately to the best of my knowledge.
Checked it with Grammarly which indeed showed an error/warning.