### PR TITLE
Use converter internally

### DIFF
--- a/test/node.js
+++ b/test/node.js
@@ -24,5 +24,12 @@ exports.node = {
     Cookies.remove('anything')
     Cookies.remove('anything', { path: '' })
     test.done()
+  },
+  shouldExposeRfc6265Converter: function (test) {
+    test.expect(2)
+    var Cookies = require('../dist/js.cookie.min.js')
+    test.ok(!!Cookies.rfc6265Converter.read)
+    test.ok(!!Cookies.rfc6265Converter.write)
+    test.done()
   }
 }

--- a/test/tests.js
+++ b/test/tests.js
@@ -530,3 +530,36 @@ QUnit.test('should be able to use read and write decoder', function (assert) {
   })
   assert.strictEqual(cookies.get('c'), '+', 'should call the read converter')
 })
+
+QUnit.test('should expose rfc 6265 converter', function (assert) {
+  assert.expect(2)
+  assert.ok(!!Cookies.rfc6265Converter.read, 'rfc 6265 converter read method is exposed')
+  assert.ok(!!Cookies.rfc6265Converter.write, 'rfc 6265 converter write method is exposed')
+})
+
+QUnit.test('should be able to reuse and extend read decoder', function (assert) {
+  assert.expect(1)
+  document.cookie = 'c=A%23'
+  var cookies = Cookies.withConverter({
+    read: function (value) {
+      var decoded = value.replace('A', 'a')
+      return Cookies.rfc6265Converter.read(decoded)
+    }
+  })
+  assert.strictEqual(cookies.get('c'), 'a#', 'should call both read converters')
+})
+
+QUnit.test('should be able to reuse and extend a write decoder', function (assert) {
+  assert.expect(1)
+  Cookies.withConverter({
+    write: function (value) {
+      var encoded = value.replace('a', 'A')
+      return Cookies.rfc6265Converter.write(encoded)
+    }
+  }).set('c', 'a%')
+  assert.strictEqual(
+    document.cookie,
+    'c=A%25',
+    'should call both write converters'
+  )
+})


### PR DESCRIPTION
I made some changes so that the library use it's own `withConverter` API internally. This has several avantages:

* using your own API is always a good idea
* minimize branching, clearer logic
* encode / decode methods are now clearly identified
* the internal converter can be exposed to user
* server-side custom converters can reuse the code (examples in SERVER_SIDE.md are greatly simplified)