### PR TITLE
Micro-optimization: optimize regex patterns for lower filesize

### DIFF
--- a/src/api.mjs
+++ b/src/api.mjs
@@ -19,7 +19,7 @@ function init (converter, defaultAttributes) {
     value = converter.write(value, key)
 
     key = encodeURIComponent(key)
-      .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
+      .replace(/%(2[346b]|5e|60|7c)/gi, decodeURIComponent)
       .replace(/[()]/g, escape)
 
     var stringifiedAttributes = ''

--- a/src/rfc6265.mjs
+++ b/src/rfc6265.mjs
@@ -1,10 +1,10 @@
 export default {
   read: function (value) {
-    return value.replace(/(%[\dA-F]{2})+/gi, decodeURIComponent)
+    return value.replace(/(%[\da-f]{2})+/gi, decodeURIComponent)
   },
   write: function (value) {
     return encodeURIComponent(value).replace(
-      /%(2[346BF]|3[ACDEF]|40|5[BDE]|60|7[BCD])/g,
+      /%(2[346bf]|3[ac-f]|40|5[bde]|60|7[bcd])/gi,
       decodeURIComponent
     )
   }


### PR DESCRIPTION
I managed to squeeze the filesize a little bit:
```
Destination: dist/js.cookie.min.mjs
Gzipped Size:  721 B => 713 B

Destination: dist/js.cookie.min.js
Gzipped Size:  819 B => 812 B
```

What has been done:
- case insensitive patterns now use lowercase
- patterns which weren't case insensitive are now case insensitive

Why does it work:
- lowercase characters have more occurences, resulting in (educated guess, haven't dug into gzip sources to be sure) shorter Huffman codes
- even though case insensitivity doesn't seems to make sense here `.replace(/[()]/gi, escape)` it actually result in longer repeated substrings, therefore we can get remove one extra byte of the gzipped artifact

What haven't worked:
I tried te reorganize character classes in this pattern `/%(2[346bf]|3[ac-f]|40|5[bde]|60|7[bcd])/` to have more repeated substrings, but I didn't get any compression gain.