### PR TITLE
Micro-optimization: replace charAt by more concise syntax

### DIFF
--- a/src/api.mjs
+++ b/src/api.mjs
@@ -60,7 +60,7 @@ function init (converter, defaultAttributes) {
       var parts = cookies[i].split('=')
       var cookie = parts.slice(1).join('=')
 
-      if (cookie.charAt(0) === '"') {
+      if (cookie[0] === '"') {
         cookie = cookie.slice(1, -1)
       }
 


### PR DESCRIPTION
I managed to squeeze the filesize a little bit:

```
Destination: dist/js.cookie.min.mjs
Gzipped Size:  721 B => 717 B

Destination: dist/js.cookie.min.js
Gzipped Size:  819 B => 814 B
```

There's no point in keepimg charAt over bracket notation, except if you plan to support IE7 or lower.
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String#Character_access

Note: combined with #576 the size goes down to:
```
Destination: dist/js.cookie.min.mjs
Gzipped Size:  721 B => 709 B

Destination: dist/js.cookie.min.js
Gzipped Size:  819 B => 803 B
```
