### PR TITLE
Fix typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,14 +253,14 @@ Cookies.remove('name')
 
 ### sameSite
 
-A [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), with possible values `lax` or `strict`, prevents the browser from sending cookie along with cross-site requests.
+A [`String`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String), with possible values `Lax` or `Strict`, prevents the browser from sending cookie along with cross-site requests.
 
 Default: not set, i.e. include cookie in any request.
 
 **Examples:**
 
 ```javascript
-Cookies.set('name', 'value', { sameSite: 'lax' })
+Cookies.set('name', 'value', { sameSite: 'Lax' })
 Cookies.get('name') // => 'value'
 Cookies.remove('name')
 ```


### PR DESCRIPTION
According the [Mozilla docs](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite) and the official [RFC](https://tools.ietf.org/html/draft-ietf-httpbis-rfc6265bis-05), the SameSite value must be written with  first character capitalized (as done in your [unit test](https://github.com/js-cookie/js-cookie/blob/master/test/tests.js#L15)).