### PR TITLE
To prevent overwriting cookie in same key when calling Cookies.get()

### DIFF
--- a/src/api.mjs
+++ b/src/api.mjs
@@ -51,7 +51,10 @@ function init (converter, defaultAttributes) {
       var parts = cookies[i].split('=')
       var value = parts.slice(1).join('=')
       var foundKey = defaultConverter.read(parts[0]).replace(/%3D/g, '=')
-      jar[foundKey] = converter.read(value, foundKey)
+      // To prevent overwriting cookie in same key
+      if (!jar[foundKey]) {
+        jar[foundKey] = converter.read(value, foundKey)
+      }
 
       if (key === foundKey) {
         break


### PR DESCRIPTION
Example in `xx.yy.com`:

```js
document.cookie = 'demo=1;domain=xx.yy.com'
document.cookie = 'demo=2;domain=yy.com'
console.log(document.cookie ) // 'demo=1; demo=2'
```

Excepted:

```js
Cookies.get('demo') === Cookies.get().demo
```

In fact:

```js
Cookies.get('demo') === '1'
Cookies.get().demo === '2'
```

This behavior may be confused.