### PR TITLE
Generate CommonJS and ESM versions of JSCookie along with the UMD version.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -46,7 +46,8 @@ const config = {
       'dist/js.cookie.mjs',
       'dist/js.cookie.min.mjs',
       'dist/js.cookie.js',
-      'dist/js.cookie.min.js'
+      'dist/js.cookie.umd.js',
+      'dist/js.cookie.umd.min.js'
     ],
     options: {
       compress: {

--- a/package.json
+++ b/package.json
@@ -2,8 +2,14 @@
   "name": "js-cookie",
   "version": "3.0.0-rc.1",
   "description": "A simple, lightweight JavaScript API for handling cookies",
-  "browser": "dist/js.cookie.js",
+  "main": "dist/js.cookie.js",
   "module": "dist/js.cookie.mjs",
+  "unpkg": "dist/js.cookie.umd.min.js",
+  "jsdelivr": "dist/js.cookie.umd.min.js",
+  "exports": {
+    "import": "dist/js.cookie.mjs",
+    "require": "dist/js.cookie.js"
+  },
   "directories": {
     "test": "test"
   },

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -21,11 +21,16 @@ export default [
       },
       // config for <script nomodule>
       {
-        file: pkg.browser,
+        file: pkg.unpkg.replace('.min.js', '.js'),
         format: 'umd',
         name: 'Cookies',
         noConflict: true,
         banner: ';'
+      },
+      // config for older Node.js versions
+      {
+        file: pkg.main,
+        format: 'cjs'
       }
     ],
     plugins: [licenseBanner]
@@ -40,7 +45,7 @@ export default [
       },
       // config for <script nomodule>
       {
-        file: pkg.browser.replace('.js', '.min.js'),
+        file: pkg.unpkg,
         format: 'umd',
         name: 'Cookies',
         noConflict: true

--- a/test/encoding.html
+++ b/test/encoding.html
@@ -5,7 +5,7 @@
     <title>JavaScript Cookie Test Suite - Encoding</title>
     <link href="../node_modules/qunit/qunit/qunit.css" rel="stylesheet" />
     <script src="../node_modules/qunit/qunit/qunit.js"></script>
-    <script src="../dist/js.cookie.min.js"></script>
+    <script src="../dist/js.cookie.umd.js"></script>
     <script src="utils.js"></script>
     <script src="encoding.js"></script>
   </head>

--- a/test/index.html
+++ b/test/index.html
@@ -8,7 +8,7 @@
     <script>
       Cookies = 'existent global'
     </script>
-    <script src="../dist/js.cookie.min.js"></script>
+    <script src="../dist/js.cookie.umd.js"></script>
     <script src="utils.js"></script>
     <script src="tests.js"></script>
   </head>

--- a/test/missing_semicolon.html
+++ b/test/missing_semicolon.html
@@ -13,7 +13,7 @@
           return xhr.status === 200 ? xhr.responseText : null
         }
 
-        var contents = loadFileSync('../dist/js.cookie.js')
+        var contents = loadFileSync('../dist/js.cookie.umd.js')
         if (contents !== null) {
           var script = document.createElement('script')
           script.innerHTML =

--- a/test/node.js
+++ b/test/node.js
@@ -1,26 +1,26 @@
 exports.node = {
   shouldLoadApi: function (test) {
     test.expect(1)
-    var Cookies = require('../dist/js.cookie.min.js')
+    var Cookies = require('../dist/js.cookie.js')
     test.ok(!!Cookies.get, 'should load the Cookies API')
     test.done()
   },
   shouldNotThrowErrorForSetCallInNode: function (test) {
     test.expect(0)
-    var Cookies = require('../dist/js.cookie.min.js')
+    var Cookies = require('../dist/js.cookie.js')
     Cookies.set('anything')
     Cookies.set('anything', { path: '' })
     test.done()
   },
   shouldNotThrowErrorForGetCallInNode: function (test) {
     test.expect(0)
-    var Cookies = require('../dist/js.cookie.min.js')
+    var Cookies = require('../dist/js.cookie.js')
     Cookies.get('anything')
     test.done()
   },
   shouldNotThrowErrorForRemoveCallInNode: function (test) {
     test.expect(0)
-    var Cookies = require('../dist/js.cookie.min.js')
+    var Cookies = require('../dist/js.cookie.js')
     Cookies.remove('anything')
     Cookies.remove('anything', { path: '' })
     test.done()


### PR DESCRIPTION
This is quite complex makes sure every environments gets the best possible module:

- unpkg and JSDelivr get a minified UMD module
- Newer Node.js versions get an ESM modules, older a CommonJS module
- The same is true for bundlers, if the bundler is configured to use ESMs it will receive it. Otherwise a CommonJS module will be used.

The use of `browser` in the old package.json is problematic as many bundles, including webpack, will by default prefer it over `module`. In that case the user ends up with an already minified UMD. The UMD is much worse, size wise, than the CommonJS version. Minified dependencies are also bad for debuging.