### PR TITLE
fix `exports` field path

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
   "name": "js-cookie",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "description": "A simple, lightweight JavaScript API for handling cookies",
   "main": "dist/js.cookie.js",
   "module": "dist/js.cookie.mjs",
   "unpkg": "dist/js.cookie.umd.min.js",
   "jsdelivr": "dist/js.cookie.umd.min.js",
   "exports": {
-    "import": "dist/js.cookie.mjs",
-    "require": "dist/js.cookie.js"
+    "import": "./dist/js.cookie.mjs",
+    "require": "./dist/js.cookie.js"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
The `exports` field contains paths that are incorrect according to [Node.js documentation](https://nodejs.org/api/packages.html#packages_exports).

This throws a `ERR_INVALID_PACKAGE_TARGET` error: https://nodejs.org/api/errors.html#errors_err_invalid_package_target

This PR fixes the issue and bumps the version