### PR TITLE
export package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,11 @@
   "unpkg": "dist/js.cookie.min.js",
   "jsdelivr": "dist/js.cookie.min.js",
   "exports": {
-    "import": "./dist/js.cookie.mjs",
-    "require": "./dist/js.cookie.js"
+    ".": {
+      "import": "./dist/js.cookie.mjs",
+      "require": "./dist/js.cookie.js"
+    },
+    "./package.json": "./package.json"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
```
rollup-plugin-svelte: The following packages did not export their `package.json` file so we could not check the `svelte` field. If you had difficulties importing svelte components from a package, then please contact the author and ask them to export the package.json file.
```

[here](https://github.com/sveltejs/rollup-plugin-svelte/issues/181) is some more context from within the svelte project