### PR TITLE
Expose all lib variants from dist

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package.json
+++ b/package.json
@@ -9,7 +9,16 @@
   "exports": {
     ".": {
       "import": "./dist/js.cookie.mjs",
-      "require": "./dist/js.cookie.js"
+      "browser": "./dist/js.cookie.js",
+      "default": "./dist/js.cookie.js"
+    },
+    "./dist/js.cookie": {
+      "import": "./dist/js.cookie.mjs",
+      "default": "./dist/js.cookie.js"
+    },
+    "./dist/js.cookie.min": {
+      "import": "./dist/js.cookie.min.mjs",
+      "default": "./dist/js.cookie.min.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
- add all built variants in ./dist to package.json's export field
- add a .npmrc to disable package-lock.json generation