### PR TITLE
Add all() method and tests

### DIFF
--- a/test/duplicate_cookie.html
+++ b/test/duplicate_cookie.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title></title>
+    <script src="../dist/js.cookie.min.js"></script>
+    <script>
+      window.__result = window.Cookies.all()
+    </script>
+  </head>
+  <body></body>
+</html>

--- a/test/utils.js
+++ b/test/utils.js
@@ -14,6 +14,12 @@
           path: ''
         })
       })
+      // Remove duplicate cookie test
+      Object.keys(Cookies.get()).forEach(function (cookie) {
+        Cookies.remove(cookie, {
+          path: '/duplicate_cookie.html'
+        })
+      })
     }
   }
 


### PR DESCRIPTION
This is a reference PR for #813 that adds `all(): Array<{ name: string, value: string }>`

This PR adds ~50 bytes to the final bundle size, keeping `dist/js.cookie.min.mjs` just barely under the 800 byte limit when gzipped.

This PR also adds a testcase that uses an `iframe` to create a scenario in which the same cookie name is set multiple times, with different values.

```
Running "compare_size:files" (compare_size) task
   raw     gz Sizes                                                            
  4052   1439 dist/js.cookie.mjs                                               
  1560    778 dist/js.cookie.min.mjs                                           
  4806   1625 dist/js.cookie.js                                                
  1863    893 dist/js.cookie.min.js                                            

   raw     gz Compared to main @ ab3f67fc4fad88cdf07b258c08e4164e06bf7506      
  +577   +194 dist/js.cookie.mjs                                               
  +132    +51 dist/js.cookie.min.mjs                                           
  +617   +196 dist/js.cookie.js                                                
  +132    +54 dist/js.cookie.min.js  
```