### PR TITLE
Prevent cookie attribute injection

### DIFF
--- a/src/assign.mjs
+++ b/src/assign.mjs
@@ -2,6 +2,7 @@ export default function (target) {
   for (var i = 1; i < arguments.length; i++) {
     var source = arguments[i]
     for (var key in source) {
+      if (key === '__proto__') continue
       target[key] = source[key]
     }
   }

--- a/test/tests.js
+++ b/test/tests.js
@@ -445,6 +445,18 @@ QUnit.test(
   }
 )
 
+QUnit.test(
+  'sanitization of attributes to prevent prototype pollution from untrusted input',
+  function (assert) {
+    var untrusted = JSON.parse('{"__proto__":{"foo":"bar"}}')
+    assert.strictEqual(
+      Cookies.set('c', 'v', untrusted),
+      'c=v; path=/',
+      'should prevent attribute-injection via prototype pollution'
+    )
+  }
+)
+
 QUnit.module('remove', lifecycle)
 
 QUnit.test('deletion', function (assert) {


### PR DESCRIPTION
Given that we are using a `for ... in` loop for assembling a cookie's
attributes required for writing/removing, we are vulnerable to prototype
pollution, where an attacker might attempt to add/overwrite certain
attributes and with that broadening access or wiping out a cookie
altogether.

Such malicious attributes input could most likely come from an object
parsed from a JSON string; for example looking like
'{"__proto__":{"samesite":"None"}}'.

Note that at the moment we're tied to using this kind of for-loop for
compatibility with IE 10 + 11.
