### PR TITLE
Fix test message typo and replace deprecated `escape()` call.

### DIFF
--- a/src/api.mjs
+++ b/src/api.mjs
@@ -18,7 +18,8 @@ function init(converter, defaultAttributes) {
 
     name = encodeURIComponent(name)
       .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
-      .replace(/[()]/g, escape)
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
 
     var stringifiedAttributes = ''
     for (var attributeName in attributes) {

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1160,7 +1160,7 @@ QUnit.test('cookie-name - 4 bytes characters', function (assert) {
   using(assert)
     .setCookie('𩸽', 'v')
     .then(function (decodedValue, plainValue) {
-      assert.strictEqual(decodedValue, 'v',       'should handle the 𩸽 character')
+      assert.strictEqual(decodedValue, 'v', 'should handle the 𩸽 character')
       assert.strictEqual(
         plainValue,
         '%F0%A9%B8%BD=v',

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1160,7 +1160,7 @@ QUnit.test('cookie-name - 4 bytes characters', function (assert) {
   using(assert)
     .setCookie('𩸽', 'v')
     .then(function (decodedValue, plainValue) {
-      assert.strictEqual(decodedValue, 'v', 'should_handle the 𩸽 character')
+      assert.strictEqual(decodedValue, 'v',       'should handle the 𩸽 character')
       assert.strictEqual(
         plainValue,
         '%F0%A9%B8%BD=v',


### PR DESCRIPTION
Two small, safe fixes I noticed while reading through the codebase:

### 1. Test message typo - `test/encoding.js`
Line 1163 had `should_handle` with an underscore instead of a space. Everything else in the test suite uses natural spacing in assertion messages, so this was just a copy-paste slip. Makes it consistent with the other ~100 messages.

### 2. Removed deprecated `escape()` - `src/api.mjs` The `set` function uses `escape()` to encode `(` and `)` in cookie names. `escape()` has been deprecated since forever and some tooling flags it. Replaced it with explicit `.replace(/\(/g, '%28').replace(/\)/g, '%29')` - same output, no behavior change, one less deprecation warning.