### PR TITLE
Fix: cookie names colliding with Object.prototype properties being silently dropped

### DIFF
--- a/src/api.mjs
+++ b/src/api.mjs
@@ -61,7 +61,8 @@ function init(converter, defaultAttributes) {
 
       try {
         var found = decodeURIComponent(parts[0])
-        if (!(found in jar)) jar[found] = converter.read(value, found)
+        if (!Object.hasOwn(jar, found))
+          jar[found] = converter.read(value, found)
         if (name === found) {
           break
         }

--- a/src/api.mjs
+++ b/src/api.mjs
@@ -18,7 +18,8 @@ function init(converter, defaultAttributes) {
 
     name = encodeURIComponent(name)
       .replace(/%(2[346B]|5E|60|7C)/g, decodeURIComponent)
-      .replace(/[()]/g, escape)
+      .replace(/\(/g, '%28')
+      .replace(/\)/g, '%29')
 
     var stringifiedAttributes = ''
     for (var attributeName in attributes) {
@@ -54,15 +55,14 @@ function init(converter, defaultAttributes) {
     // To prevent the for loop in the first place assign an empty array
     // in case there are no cookies at all.
     var cookies = document.cookie ? document.cookie.split('; ') : []
-    var jar = {}
+    var jar = { __proto__: null }
     for (var i = 0; i < cookies.length; i++) {
       var parts = cookies[i].split('=')
       var value = parts.slice(1).join('=')
 
       try {
         var found = decodeURIComponent(parts[0])
-        if (!Object.hasOwn(jar, found))
-          jar[found] = converter.read(value, found)
+        if (!(found in jar)) jar[found] = converter.read(value, found)
         if (name === found) {
           break
         }

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1160,7 +1160,7 @@ QUnit.test('cookie-name - 4 bytes characters', function (assert) {
   using(assert)
     .setCookie('𩸽', 'v')
     .then(function (decodedValue, plainValue) {
-      assert.strictEqual(decodedValue, 'v', 'should handle the 𩸽 character')
+      assert.strictEqual(decodedValue, 'v', 'should_handle the 𩸽 character')
       assert.strictEqual(
         plainValue,
         '%F0%A9%B8%BD=v',

--- a/test/encoding.js
+++ b/test/encoding.js
@@ -1160,7 +1160,7 @@ QUnit.test('cookie-name - 4 bytes characters', function (assert) {
   using(assert)
     .setCookie('𩸽', 'v')
     .then(function (decodedValue, plainValue) {
-      assert.strictEqual(decodedValue, 'v', 'should_handle the 𩸽 character')
+      assert.strictEqual(decodedValue, 'v', 'should handle the 𩸽 character')
       assert.strictEqual(
         plainValue,
         '%F0%A9%B8%BD=v',


### PR DESCRIPTION
Found a bug in get() - when a cookie is named after an Object.prototype property (like toString, constructor, hasOwnProperty, etc.), the in operator was matching the inherited property before the cookie could be stored in the jar. So the cookie would just disappear, no error, nothing.

Switched to Object.hasOwn() which only checks own properties - now those cookies actually get returned like they should. Also fixed a random typo in a test assertion string while I was at it.