### PR TITLE
Ensure ECMAScript compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,11 @@ jobs:
         run: npm run lint:check
       - name: Run unit tests
         run: npm test
+      - name: Check ECMAScript compatibility
+        run: |
+          npm run dist
+          npx eslint --no-config-lookup --parser espree --parser-options 'ecmaVersion:5,sourceType:script' 'dist/*.js'
+          npx eslint --no-config-lookup --parser-options 'ecmaVersion:6' 'dist/*.mjs'
 
   e2e-test:
     runs-on: ubuntu-latest

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -27,5 +27,50 @@ export default defineConfig([
       ...languageOptions,
       ecmaVersion: 2021
     }
+  },
+  // NOTE: we are not transpiling the distributed modules, therefore must
+  // refrain from using certain ES syntax not supported by IE/ES5. The rules
+  // specified here do not provide full coverage, only for the most prominent
+  // features that aren't ES5..
+  {
+    files: ['src/**/*.mjs'],
+    rules: {
+      'no-restricted-syntax': [
+        'error',
+        {
+          selector: 'ArrowFunctionExpression',
+          message: 'Arrow functions are not ES5 compatible.'
+        },
+        {
+          selector: 'CatchClause[param=null]',
+          message: 'Optional catch bindings are not ES5 compatible.'
+        },
+        {
+          selector: 'ForOfStatement',
+          message: 'for...of loops are not ES5 compatible.'
+        },
+        {
+          selector: 'Property[method=true]',
+          message: 'Shorthand method definitions are not ES5 compatible.'
+        },
+        {
+          selector: 'Property[shorthand=true]',
+          message: 'Shorthand properties are not ES5 compatible.'
+        },
+        {
+          selector: 'TemplateLiteral',
+          message: 'Template literals are not ES5 compatible.'
+        },
+        {
+          selector: 'VariableDeclaration[kind="let"]',
+          message: 'let declarations are not ES5 compatible.'
+        },
+        {
+          selector: 'VariableDeclaration[kind="const"]',
+          message: 'const declarations are not ES5 compatible.'
+        }
+      ],
+      'no-unused-vars': ['error', { caughtErrorsIgnorePattern: '^_' }]
+    }
   }
 ])

--- a/src/api.mjs
+++ b/src/api.mjs
@@ -65,7 +65,7 @@ function init(converter, defaultAttributes) {
         if (name === found) {
           break
         }
-      } catch {
+      } catch (_e) {
         // Do nothing...
       }
     }
@@ -75,8 +75,8 @@ function init(converter, defaultAttributes) {
 
   return Object.create(
     {
-      set,
-      get,
+      set: set,
+      get: get,
       remove: function (name, attributes) {
         set(
           name,


### PR DESCRIPTION
In the recent release we broke ES5 compatibility after having migrated
ESLint configuration some time ago and opting into a more recent
ECMAScript version in its configuration (which us useful for auxiliary
code, but must not be allowed in the lib's source itself: we are still
supposed to support IE 10 + 11 with version 3, which means ES5 is the
baseline).

Due to a peculiarity in the source, which is generally not transpiled
except for `import` statements being replaced by Rollup when releasing
we can't configure ESLint to just lint sources with `ecmaVersion: 5`, as
this isn't compatible with the module import/export syntax. Hence here
we're configuring certain code exclusion rules manually to account for
the most prominent language constructs not compatible with ES5. This is
supposed to provide faster feedback during development but does not
cover all incompatible syntax.

So to ensure full ES5 compatibility, a check is added in CI to verify
the dists that are being produced are compatible. This covers full ES5
compatibility for the CommonJS dist variants (`dist/*.js`), whereas it
must be ES6 for the ES modules (`dist/*.mjs`).

Closes #959
