### PR TITLE
Remove pinning of npm in GitHub Actions workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,8 +76,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: package.json
-          check-latest: true
+          node-version: 24.x
       - name: Install dependencies
         run: |
           npm i -g npm@11.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,7 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: package.json
-          check-latest: true
+          node-version: ${{ matrix.node-version }}
       - name: Install dependencies
         run: |
           npm i -g npm@11.8.0
@@ -77,8 +76,7 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version-file: package.json
-          check-latest: true
+          node-version: 24.x
       - name: Install dependencies
         run: |
           npm i -g npm@11.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm i -g npm@11.8.0
+          npm ci
       - name: Check formatting
         run: npm run format:check
       - name: Lint
@@ -77,7 +79,9 @@ jobs:
           node-version-file: package.json
           check-latest: true
       - name: Install dependencies
-        run: npm ci
+        run: |
+          npm i -g npm@11.8.0
+          npm ci
       - name: Run BrowserStack E2E tests
         run: NODE_NO_WARNINGS=1 npm run test:browserstack
       - name: Stop BrowserStackLocal

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,8 @@ jobs:
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version-file: package.json
+          check-latest: true
       - name: Install dependencies
         run: |
           npm i -g npm@11.8.0
@@ -76,7 +77,8 @@ jobs:
           persist-credentials: false
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
-          node-version: 24.x
+          node-version-file: package.json
+          check-latest: true
       - name: Install dependencies
         run: |
           npm i -g npm@11.8.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,7 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Install dependencies
-        run: |
-          npm i -g npm@11.8.0
-          npm ci
+        run: npm ci
       - name: Check formatting
         run: npm run format:check
       - name: Lint
@@ -79,9 +77,7 @@ jobs:
           node-version-file: package.json
           check-latest: true
       - name: Install dependencies
-        run: |
-          npm i -g npm@11.8.0
-          npm ci
+        run: npm ci
       - name: Run BrowserStack E2E tests
         run: NODE_NO_WARNINGS=1 npm run test:browserstack
       - name: Stop BrowserStackLocal

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,9 +37,7 @@ jobs:
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
-      - run: |
-          npm i -g npm@11.8.0
-          npm ci
+      - run: npm ci
       - uses: chainguard-dev/actions/setup-gitsign@081e79ee578199ef583d4ca74edc376b50b9409c
       - run: npm run release ${GITHUB_EVENT_INPUTS_BUMP}${{ github.event.inputs.dry-run == 'true' && ' -- --dry-run' || '' }}
         env:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,7 +37,9 @@ jobs:
         with:
           node-version: 24.x
           registry-url: https://registry.npmjs.org
-      - run: npm ci
+      - run: |
+          npm i -g npm@11.8.0
+          npm ci
       - uses: chainguard-dev/actions/setup-gitsign@081e79ee578199ef583d4ca74edc376b50b9409c
       - run: npm run release ${GITHUB_EVENT_INPUTS_BUMP}${{ github.event.inputs.dry-run == 'true' && ' -- --dry-run' || '' }}
         env:


### PR DESCRIPTION
This pinning, e.g attempting to install a particular npm version now
seemingly started to break CI, while we pinned it to work around an
issue with Dependabot, see commit
2400349401697da8463c9db18ecb208a11694de3 and
cdaa884d1fd0b8497f6b2fe695df6c968c00fa42. The Dependabot issue seems to
be fixed.

For publishing with Trusted Publisher we use Node 24, according to
documentation it "includes a compatible npm version by default".

https://github.com/actions/setup-node/blob/0355742c943ddb13ca8a6b700f824231caa91e75/docs/advanced-usage.md#publishing-to-npm-with-trusted-publisher-oidc
t
