### PR TITLE
Remove QUnit related workaround in Grunt config

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,15 +21,6 @@ function encodingMiddleware(request, response, next) {
 
 const config = {
   qunit: {
-    options: {
-      puppeteer: {
-        headless: 'new'
-      },
-      inject: [
-        'test/fix-qunit-reference.js', // => https://github.com/gruntjs/grunt-contrib-qunit/issues/202
-        'node_modules/grunt-contrib-qunit/chrome/bridge.js'
-      ]
-    },
     all: {
       options: {
         urls: [


### PR DESCRIPTION
We are having grunt-contrib-qunit 10.2.0, which includes the removed config.